### PR TITLE
reuse frame transform interfaces for packet transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ RTP interfaces inherit from `FrameTransformerHost` to support SFrame injection:
 class RtpSenderInterface : public FrameTransformerHost {
  public:
   void SetFrameTransformer(
-      scoped_refptr<SFrameTransformerInterface> frame_transformer) {};
+      scoped_refptr<FrameTransformerInterface> frame_transformer) {};
 
   void SetPacketTransformer(
-      scoped_refptr<SFrameTransformerInterface> packet_transformer) {};
+      scoped_refptr<FrameTransformerInterface> packet_transformer) {};
 };
 ```
 
@@ -52,9 +52,9 @@ class RtpSenderInterface : public FrameTransformerHost {
 class RtpReceiverInterface : public FrameTransformerHost {
  public:
   void SetFrameTransformer(
-      scoped_refptr<SFrameTransformerInterface> frame_transformer) {};
+      scoped_refptr<FrameTransformerInterface> frame_transformer) {};
 
   void SetPacketTransformer(
-      scoped_refptr<SFrameTransformerInterface> packet_transformer) {};
+      scoped_refptr<FrameTransformerInterface> packet_transformer) {};
 };
 ```

--- a/README.md
+++ b/README.md
@@ -8,267 +8,53 @@ SFrame encryption can be applied at two different levels:
 - **Per-frame**: Encrypts complete video/audio frames before packetization
 - **Per-packet**: Encrypts individual RTP packets after packetization
 
-Both approaches offer strong security guarantees, with per-packet providing finer granularity and per-frame offering better performance characteristics.
+## Architecture
 
-## JavaScript API
+The SFrame implementation leverages and extends WebRTC's existing transformer infrastructure:
 
-### SFrame Modes
+1. **`FrameTransformerHost`** - Base interface that provides `SetFrameTransformer()` and `SetPacketTransformer()` methods.
+2. **`FrameTransformerInterface`** - For frame-level and packet-level encryption (defined in `api/frame_transformer_interface.h`)
+3. **`TransformableFrameInterface`** - Base interface to be used for Frame and Packet level encryption (defined in `api/frame_transformer_interface.h`)
 
-```javascript
-// Available modes for SFrame encryption
-const SFrameMode = {
-    "per-frame",   // Encrypt at frame level
-    "per-packet"   // Encrypt at packet level
-};
-```
+### Extend `FrameTransformerHost`
 
-### Basic Usage
+`FrameTransformerHost` should have an ability to handle both - frame and packet level transformers. Extend it to allow setting also packet level transformers.
 
-Assumption; JS API usage after recent W3C meeting.
-
-```javascript
-// Create peer connection
-const peerConnection = new RTCPeerConnection();
-
-// Add video track
-const videoTransceiver = peerConnection.addTransceiver("video", {
-  direction: "sendonly"
-});
-
-// Configure SFrame options
-const sframeOptions = {
-  mode: "per-packet"  // or "per-frame"
-};
-
-// Apply SFrame transform
-videoTransceiver.sender.transform = new SFrameTransform(sframeOptions);
-```
-
-### Key Points
-
-- SFrame can be configured independently for each media track
-- Both sender and receiver need compatible SFrame configurations
-- The API maintains backward compatibility with non-SFrame endpoints
-
-## C++ API
-
-The SFrame API design provides transformer injection at the sender and receiver level, following the JavaScript API pattern:
-
-```javascript
-videoTransceiver.sender.transform = new SFrameTransform(sframeOptions);
-```
-
-Following this design proposal principles, the `SetSFrameTransformer` method will be exposed through the `RTPSenderInterface` and `RTPReceiverInterface` to provide this granular control and maintain consistency with the JavaScript API surface.
-
-### Core Interfaces
-
-#### SFrameMode Enumeration
-
-Defines the granularity at which SFrame encryption is applied to media data.
-
-`api/sframe/sframe_options.h`
 ```cpp
-enum SFrameMode {
-  kPerFrame,   // Frame-level encryption
-  kPerPacket   // Packet-level encryption
-};
-```
-
-#### SFrameOptions Configuration
-
-Configuration structure that defines SFrame encryption behavior.
-
-`api/sframe/sframe_options.h`
-```cpp
-struct SFrameOptions {
-    SFrameMode mode;
-    // Additional options can be added here in the future
-};
-```
-
-#### SFrameTransformerHost Interface
-
-The `SFrameTransformerHost` interface provides a unified way to inject SFrame transformers into WebRTC components. This interface will be implemented by RTP senders and receivers to enable SFrame encryption and decryption capabilities.
-
-`api/sframe/sframe_transformer_interface.h`
-```cpp
-class SFrameTransformerHost {
+class FrameTransformerHost {
  public:
-  virtual ~SFrameTransformerHost() = default;
-
-  // Configures SFrame transformer with specified options
-  virtual void SetSFrameTransformer(
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options) = 0;
-
-  // Retrieves currently configured transformer (may return nullptr)
-  virtual scoped_refptr<SFrameTransformerInterface> GetSFrameTransformer() = 0;
+  virtual ~FrameTransformerHost() {}
+  virtual void SetFrameTransformer(
+      scoped_refptr<FrameTransformerInterface> frame_transformer) = 0;
+  virtual void SetPacketTransformer(
+      scoped_refptr<FrameTransformerInterface> packet_transformer) = 0;
 };
 ```
 
-#### SFrame Transformer Interface
+### RTP Senders/Receivers
 
-The main interface for implementing SFrame encryption/decryption:
-
-`api/sframe/sframe_transformer_interface.h`
-```cpp
-class SFrameTransformerInterface : public RefCountInterface {
- public:
-  virtual ~SFrameTransformerInterface() = default;
-
-  // Configure encryption keys
-  virtual void SetEncryptionKey(/*Keys*/) = 0;
-
-  // Transform media data (encrypt or decrypt)
-  virtual void Transform(CopyOnWriteBuffer buffer) = 0;
-};
-```
-
-#### Integration with RTP Senders/Receivers
-
-RTP interfaces inherit from `SFrameTransformerHost` to support SFrame injection:
+RTP interfaces inherit from `FrameTransformerHost` to support SFrame injection:
 
 `api/rtp_sender_interface.h`
 ```cpp
-class RtpSenderInterface : public SFrameTransformerHost {
+class RtpSenderInterface : public FrameTransformerHost {
  public:
-  // Default implementation, actuall implementation will be done by classes inheriting RtpSenderInterface
-  void SetSFrameTransformer(
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options) {};
+  void SetFrameTransformer(
+      scoped_refptr<SFrameTransformerInterface> frame_transformer) {};
+
+  void SetPacketTransformer(
+      scoped_refptr<SFrameTransformerInterface> packet_transformer) {};
 };
 ```
 
 `api/rtp_receiver_interface.h`
 ```cpp
-class RtpReceiverInterface : public SFrameTransformerHost {
+class RtpReceiverInterface : public FrameTransformerHost {
  public:
- // Default implementation, actuall implementation will be done by classes inheriting RtpReceiverInterface
-  void SetSFrameTransformer(
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options) {};
+  void SetFrameTransformer(
+      scoped_refptr<SFrameTransformerInterface> frame_transformer) {};
+
+  void SetPacketTransformer(
+      scoped_refptr<SFrameTransformerInterface> packet_transformer) {};
 };
-```
-
-### Cisco SFrame Library
-
-WebRTC will provide a built-in SFrame implementation using the [Cisco SFrame](https://github.com/cisco/sframe) library.
-
-#### Encrypt or decrypt
-
-Decision whether SFrameTransformer should perform encryption or decryption will be defined by the `SFrameRole` parameter.
-
-`api/sframe/sframe_transformer.h`
-```cpp
-enum SFrameRole {
-  Encrypt,
-  Decrypt
-};
-```
-
-#### Supported Cipher Suites
-
-`api/sframe/sframe_transformer.h`
-```cpp
-enum SFrameCipherSuite {
-  AES_128_CTR_HMAC_SHA256_8,   // AES-128-CTR with 8-byte auth tag
-  AES_128_CTR_HMAC_SHA256_64,  // AES-128-CTR with 64-byte auth tag
-  AES_128_CTR_HMAC_SHA256_32,  // AES-128-CTR with 32-byte auth tag
-  AES_128_GCM_SHA256_128,      // AES-128-GCM with 128-bit auth tag
-  AES_256_GCM_SHA512_128       // AES-256-GCM with 128-bit auth tag
-};
-```
-
-#### RTCSFrameTransformer
-
-`RTCSFrameTransformer` will leverage [Cisco SFrame](https://github.com/cisco/sframe) library to implement SFrame encryption/decryption.
-
-`modules/sframe/rtc_sframe_transformer.h`
-```cpp
-class RTCSFrameTransformer : public SFrameTransformerInterface {
- public:
-  explicit RTCSFrameTransformer(SFrameRole role, SFrameCipherSuite cipher_suite);
-
-  void SetEncryptionKey(std::string key) override {
-    // Update keys in SFrame Context
-  }
-
-  // Transform media data (encrypt or decrypt)
-  void Transform(CopyOnWriteBuffer buffer) override {
-    // role == SFrameRole::Encrypt ? Encrypt(buffer) : Decrypt(buffer);
-  }
-
-private:
-  void Encrypt(CopyOnWriteBuffer buffer);
-
-  void Decrypt(CopyOnWriteBuffer buffer);
-};
-```
-
-#### RTCSFrameTransformer Factory
-
-`RTCSFrameTransformer` creation will be possible throught the factory method exposed from the libwebrtc API.
-
-`api/sframe/sframe_transformer_factory.h`
-```cpp
-scoped_refptr<SFrameTransformerInterface> CreateSFrameTransformer(SFrameRole role, SFrameCipherSuite cipher_suite);
-```
-
-```cpp
-scoped_refptr<SFrameTransformerInterface> CreateSFrameTransformer(SFrameRole role, SFrameCipherSuite cipher_suite)
-{
-  return make_ref_counted<RTCSFrameTransformer>(role, cipher_suite);
-}
-```
-
-### Complete Usage Example
-
-```cpp
-// Create peer connection
-RTCPeerConnection pc;
-
-// Add video transceiver
-auto transceiver = pc.AddTransceiver("video");
-
-// Create SFrame transformer for encryption
-auto sframe_transformer = CreateSFrameTransformer(SFrameRole::kEncrypt, 
-    SFrameCipherSuite::AES_128_GCM_SHA256_128);
-
-// Configure for per-packet encryption
-SFrameOptions options;
-options.mode = SFrameMode::kPerPacket;
-
-// Apply to sender
-transceiver->sender()->SetSFrameTransformer(sframe_transformer, options);
-
-sframe_transformer->SetEncryptionKey("XYZ");
-```
-
-## Additional Resources
-
-### Related Specifications
-- [SFrame Protocol](https://datatracker.ietf.org/doc/draft-omara-sframe/) - The underlying SFrame specification
-- [WebRTC API](https://w3c.github.io/webrtc-pc/) - W3C WebRTC specification
-- [Cisco SFrame Library](https://github.com/cisco/sframe) - Reference implementation
-- [RTP SFrame](https://datatracker.ietf.org/doc/draft-ietf-avtcore-rtp-sframe)
-- [Encoded Transform](https://www.w3.org/TR/webrtc-encoded-transform)
-
-**Open Questions:**
-- Should we use `CopyOnWriteBuffer` or rather `ArraView<uint8_t>` for transformation
-- Do we need on libwebrtc level to have single "Transformer" interface. 
-  Maybe it's fine to split it into encrypter and decrypter, and let browser level code decide which to create.
-  Instead of having an generic `RTCSFrameTransformer` with `SFrameRole` in the parameter, we could create a separate objects for handling encryption and decryption.
-
-```cpp
-  class RTCSFrameEncryptor : public SFrameTransformerInterface {
-  public:
-    explicit RTCSFrameEncryptor(SFrameCipherSuite cipher_suite);
-    // Implementation handles the crypto details
-  };
-
-  class RTCSFrameDecryptor : public SFrameTransformerInterface {
-  public:
-    explicit RTCSFrameDecryptor(SFrameCipherSuite cipher_suite);
-    // Implementation handles the crypto details
-  };
 ```

--- a/blink-rtc-rtp-script-transform.md
+++ b/blink-rtc-rtp-script-transform.md
@@ -1,0 +1,253 @@
+# Blink RTCRtpScriptTransform
+
+This document describes how RTCRtpScriptTransform is integrated into the Blink layer and how it was extended to support both frame-level and packet-level transformations.
+
+## Overview
+
+`RTCRtpScriptTransform` is the existing JavaScript-accessible transform that allows custom processing of encoded frames through Web Workers. With the SFrame integration, it has been extended to support both frame-level and packet-level transformers, enabling it to work alongside `SFrameTransform` as part of the unified `RTCRtpTransform` interface.
+
+## IDL
+
+The RTCRtpScriptTransform interface remains unchanged in IDL, but it's now part of the RTCRtpTransform union type.
+
+`third_party/blink/renderer/modules/peerconnection/rtc_rtp_transform.idl`
+```idl
+typedef (SFrameTransform or RTCRtpScriptTransform) RTCRtpTransform;
+```
+
+The original RTCRtpScriptTransform interface continues to exist with its original functionality:
+```idl
+[Exposed=(Window,Worker)]
+interface RTCRtpScriptTransform {
+    constructor(Worker worker, optional any options, optional sequence<object> transfer);
+    
+    readonly attribute ReadableStream readable;
+    readonly attribute WritableStream writable;
+};
+```
+
+## RTCRtpScriptTransform
+
+`RTCRtpScriptTransform` is the C++ layer associated with the JavaScript transform that enables custom frame processing via Web Workers.
+
+`third_party/blink/renderer/modules/peerconnection/rtc_rtp_script_transform.h`
+```cpp
+class MODULES_EXPORT RTCRtpScriptTransform : public ScriptWrappable {
+  DEFINE_WRAPPERTYPEINFO();
+
+ public:
+  static RTCRtpScriptTransform* Create(
+      ScriptState* script_state,
+      Worker* worker,
+      const ScriptValue& options,
+      const HeapVector<ScriptValue>& transfer,
+      ExceptionState& exception_state);
+
+  explicit RTCRtpScriptTransform(/* constructor parameters */);
+  ~RTCRtpScriptTransform() override = default;
+
+  // Expose readable/writable for pipeThrough usage
+  ReadableStream* readable() const { return readable_; }
+  WritableStream* writable() const { return writable_; }
+
+  // Called when this transform is assigned to an RTCRtpSender or
+  // RTCRtpReceiver via setTransform().
+  void CreateAudioUnderlyingSourceAndSink(
+      CrossThreadOnceClosure disconnect_callback_source,
+      scoped_refptr<blink::RTCEncodedAudioStreamTransformer::Broker>
+          encoded_audio_transformer);
+
+  void CreateVideoUnderlyingSourceAndSink(
+      CrossThreadOnceClosure disconnect_callback_source,
+      scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+          encoded_video_frame_transformer,
+      scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+          encoded_video_packet_transformer);
+
+  void Attach();
+  void Detach();
+  bool HasBeenUsed() const;
+
+  void Trace(Visitor* visitor) const override;
+
+ private:
+  // Streams exposed for pipeThrough usage
+  Member<ReadableStream> readable_;
+  Member<WritableStream> writable_;
+
+  // The Web Worker that processes frames
+  Member<Worker> worker_;
+
+  // RTP transformer handles frame processing in worker context
+  std::optional<CrossThreadWeakHandle<RTCRtpScriptTransformer>> rtp_transformer_;
+  scoped_refptr<base::SingleThreadTaskRunner> rtp_transformer_task_runner_;
+
+  // Extended to support both frame and packet transformers
+  scoped_refptr<blink::RTCEncodedAudioStreamTransformer::Broker>
+      encoded_audio_transformer_;
+  scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+      encoded_video_frame_transformer_;
+  scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+      encoded_video_packet_transformer_;
+  
+  CrossThreadOnceClosure disconnect_callback_source_;
+  
+  bool is_attached_ = false;
+  bool is_unused_ = true;
+};
+```
+
+The key changes from the original implementation:
+
+1. **Dual Transformer Support**: `CreateVideoUnderlyingSourceAndSink` now accepts both frame-level and packet-level transformer brokers
+2. **Extended State Management**: Tracks both frame and packet transformers separately
+3. **Unified Interface**: Works as part of the RTCRtpTransform union alongside SFrameTransform
+
+## Key Methods Implementation
+
+### CreateVideoUnderlyingSourceAndSink
+
+The method was extended to handle both frame-level and packet-level transformers:
+
+```cpp
+void RTCRtpScriptTransform::CreateVideoUnderlyingSourceAndSink(
+    CrossThreadOnceClosure disconnect_callback_source,
+    scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+        encoded_video_frame_transformer,
+    scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+        encoded_video_packet_transformer) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  
+  if (rtp_transformer_) {
+    // If transformer is available, set up immediately
+    SetUpVideoRtpTransformer(std::move(disconnect_callback_source),
+                             std::move(encoded_video_frame_transformer),
+                             std::move(encoded_video_packet_transformer));
+  } else {
+    // Store for later setup when transformer becomes available
+    encoded_video_frame_transformer_ = std::move(encoded_video_frame_transformer);
+    encoded_video_packet_transformer_ = std::move(encoded_video_packet_transformer);
+    disconnect_callback_source_ = std::move(disconnect_callback_source);
+  }
+}
+```
+
+### SetUpVideoRtpTransformer
+
+Updated to handle dual transformer setup:
+
+```cpp
+void RTCRtpScriptTransform::SetUpVideoRtpTransformer(
+    CrossThreadOnceClosure disconnect_callback_source,
+    scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+        encoded_video_frame_transformer,
+    scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+        encoded_video_packet_transformer) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  CHECK(rtp_transformer_);
+  
+  PostCrossThreadTask(
+      *rtp_transformer_task_runner_, FROM_HERE,
+      CrossThreadBindOnce(
+          &RTCRtpScriptTransformer::SetUpVideo,
+          MakeUnwrappingCrossThreadWeakHandle(*rtp_transformer_),
+          std::move(disconnect_callback_source),
+          std::move(encoded_video_frame_transformer),
+          std::move(encoded_video_packet_transformer)));
+}
+```
+
+## RTCRtpScriptTransformer
+
+`RTCRtpScriptTransformer` runs in the Web Worker context and handles the actual frame processing. It was also extended to support dual transformers.
+
+```cpp
+class MODULES_EXPORT RTCRtpScriptTransformer : public ScriptWrappable {
+ public:
+  RTCRtpScriptTransformer(ScriptState* script_state, 
+                          CrossThreadWeakHandle<RTCRtpScriptTransform> transform);
+  ~RTCRtpScriptTransformer() override = default;
+
+  // Exposes readable/writable streams to the Worker
+  ReadableStream* readable(ScriptState* script_state);
+  WritableStream* writable(ScriptState* script_state);
+
+  void SetUpAudio(CrossThreadOnceClosure disconnect_callback_source,
+                  scoped_refptr<blink::RTCEncodedAudioStreamTransformer::Broker>
+                      encoded_audio_transformer);
+
+  void SetUpVideo(CrossThreadOnceClosure disconnect_callback_source,
+                  scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+                      encoded_video_frame_transformer,
+                  scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+                      encoded_video_packet_transformer);
+
+  void Clear();
+
+  // Extended functionality for transformation features
+  scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker> GetVideoBroker();
+  void SetVideoTransformationFeatures(
+      const Vector<webrtc::TransformationFeature>& features);
+
+  void Trace(Visitor* visitor) const override;
+
+ private:
+  const Member<ScriptState> script_state_;
+  Member<RTCEncodedUnderlyingSourceWrapper> rtc_encoded_underlying_source_;
+  Member<RTCEncodedUnderlyingSinkWrapper> rtc_encoded_underlying_sink_;
+  
+  // Cached streams for worker access
+  Member<ReadableStream> readable_;
+  Member<WritableStream> writable_;
+};
+```
+
+### SetUpVideo Implementation
+
+```cpp
+void RTCRtpScriptTransformer::SetUpVideo(
+    CrossThreadOnceClosure disconnect_callback_source,
+    scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+        encoded_video_frame_transformer,
+    scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+        encoded_video_packet_transformer) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  base::UnguessableToken owner_id = base::UnguessableToken::Create();
+
+  // For now, default to frame-level transformer
+  // Custom logic could be added here to choose based on worker configuration
+  scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker> selected_transformer =
+      std::move(encoded_video_frame_transformer);
+
+  rtc_encoded_underlying_source_->CreateVideoUnderlyingSource(
+      std::move(disconnect_callback_source), owner_id);
+  selected_transformer->SetTransformerCallback(
+      rtc_encoded_underlying_source_->GetVideoTransformer());
+  selected_transformer->SetSourceTaskRunner(rtp_transformer_task_runner_);
+  rtc_encoded_underlying_sink_->CreateVideoUnderlyingSink(
+      std::move(selected_transformer), owner_id);
+}
+```
+
+## Integration with RTCRtpSender/Receiver
+
+The RTCRtpScriptTransform integrates with the updated RTCRtpSender/Receiver interfaces that now handle the RTCRtpTransform union type:
+
+```cpp
+// In RTCRtpSender::setTransform
+if (transform->IsRTCRtpScriptTransform()) {
+    RTCRtpScriptTransform* script_transform = 
+        transform->GetAsRTCRtpScriptTransform();
+    
+    script_transform->Attach();
+    
+    if (kind_ == "video") {
+        script_transform->CreateVideoUnderlyingSourceAndSink(
+            CrossThreadBindOnce(&RTCRtpSender::UnregisterEncodedVideoStreamCallback,
+                                WrapCrossThreadWeakPersistent(this)),
+            encoded_video_transformer_,
+            encoded_video_packet_transformer_);
+    }
+    // Similar for audio...
+}
+```

--- a/blink-rtc-rtp-sender.md
+++ b/blink-rtc-rtp-sender.md
@@ -1,0 +1,216 @@
+# Blink RTCRtpSender
+
+## Overview
+
+This document describes how to integrate SFrame (Secure Frame) encryption into the Blink RTCRtpSender.
+
+## RTCRtpSenderImpl::RTCRtpSenderInternal
+
+`RTCRtpSenderImpl::RTCRtpSenderInternal` registers both - `Frame` and `Packet` level transformers.
+
+```cpp
+class RTCRtpSenderImpl::RTCRtpSenderInternal
+    : public ThreadSafeRefCounted<
+          RTCRtpSenderImpl::RTCRtpSenderInternal,
+          RTCRtpSenderImpl::RTCRtpSenderInternalTraits> {
+ public:
+  RTCRtpSenderInternal(
+      webrtc::scoped_refptr<webrtc::PeerConnectionInterface>
+          native_peer_connection,
+      scoped_refptr<blink::WebRtcMediaStreamTrackAdapterMap> track_map,
+      RtpSenderState state)
+      : native_peer_connection_(std::move(native_peer_connection)),
+        track_map_(std::move(track_map)),
+        main_task_runner_(state.main_task_runner()),
+        signaling_task_runner_(state.signaling_task_runner()),
+        webrtc_sender_(state.webrtc_sender()),
+        state_(std::move(state)) {
+    DCHECK(track_map_);
+    DCHECK(state_.is_initialized());
+    if (webrtc_sender_->media_type() == webrtc::MediaType::AUDIO) {
+      encoded_audio_frame_transformer_ =
+          std::make_unique<RTCEncodedAudioStreamTransformer>(main_task_runner_);
+      webrtc_sender_->SetFrameTransformer(
+          encoded_audio_frame_transformer_->Delegate());
+
+      encoded_audio_packet_transformer_ =
+          std::make_unique<RTCEncodedAudioStreamTransformer>(main_task_runner_);
+      webrtc_sender_->SetPacketTransformer(
+        encoded_audio_packet_transformer_->Delegate());
+    } else {
+      CHECK(webrtc_sender_->media_type() == webrtc::MediaType::VIDEO);
+      encoded_video_frame_transformer_ =
+          std::make_unique<RTCEncodedVideoStreamTransformer>(
+              main_task_runner_, /*metronome=*/nullptr);
+      webrtc_sender_->SetFrameTransformer(
+          encoded_video_frame_transformer_->Delegate());
+
+      encoded_video_packet_transformer_ =
+          std::make_unique<RTCEncodedVideoStreamTransformer>(
+              main_task_runner_, /*metronome=*/nullptr);
+      webrtc_sender_->SetFrameTransformer(
+          encoded_video_packet_transformer_->Delegate());
+    }
+  }
+
+  RTCEncodedAudioStreamTransformer* GetEncodedAudioFrameStreamTransformer() const {
+    return encoded_audio_frame_transformer_.get();
+  }
+
+  RTCEncodedVideoStreamTransformer* GetEncodedVideoFrameStreamTransformer() const {
+    return encoded_video_frame_transformer_.get();
+  }
+
+  RTCEncodedAudioStreamTransformer* GetEncodedAudioPacketStreamTransformer() const {
+    return encoded_audio_packet_transformer_.get();
+  }
+
+  RTCEncodedVideoStreamTransformer* GetEncodedVideoPacketStreamTransformer() const {
+    return encoded_video_packet_transformer_.get();
+  }
+
+ private:
+  // Frame Transformers
+  std::unique_ptr<RTCEncodedAudioStreamTransformer> encoded_audio_frame_transformer_;
+  std::unique_ptr<RTCEncodedVideoStreamTransformer> encoded_video_frame_transformer_;
+  // Packet Transformers
+  std::unique_ptr<RTCEncodedAudioStreamTransformer> encoded_audio_packet_transformer_;
+  std::unique_ptr<RTCEncodedVideoStreamTransformer> encoded_video_packet_transformer_;
+}
+```
+
+## RTCRtpSender
+
+This class provides direct binding between Javascript and C++ layer for senders.
+It will store now brokers associated with both `Frame` and `Packet` level transformations.
+
+```cpp
+class MODULES_EXPORT RTCRtpSenderImpl : public blink::RTCRtpSenderPlatform {
+ public:
+  V8UnionRTCRtpScriptTransformOrSFrameTransform* transform() { return transform_.Get(); }
+  void setTransform(V8UnionRTCRtpScriptTransformOrSFrameTransform*, ExceptionState& exception_state);
+ private:
+  Member<V8UnionRTCRtpScriptTransformOrSFrameTransform> transform_;
+
+ const scoped_refptr<blink::RTCEncodedAudioStreamTransformer::Broker>
+      encoded_audio_frame_transformer_;
+ const scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+      encoded_video_frame_transformer_;
+
+ // Packet-level transformer brokers
+ const scoped_refptr<blink::RTCEncodedAudioStreamTransformer::Broker>
+      encoded_audio_packet_transformer_;
+ const scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+      encoded_video_packet_transformer_;
+}
+```
+
+`RTCRtpSender::RTCRtpSender` will initialized in the constructor `Broker`s provided from the `RTCRtpSenderImpl::RTCRtpSenderInternal`.
+
+```cpp
+RTCRtpSender::RTCRtpSender(RTCPeerConnection* pc,
+                           std::unique_ptr<RTCRtpSenderPlatform> sender,
+                           String kind,
+                           MediaStreamTrack* track,
+                           MediaStreamVector streams,
+                           bool require_encoded_insertable_streams,
+                           scoped_refptr<base::SequencedTaskRunner>
+                               encoded_transform_shortcircuit_runner)
+    : ExecutionContextLifecycleObserver(pc->GetExecutionContext()),
+      pc_(pc),
+      sender_(std::move(sender)),
+      kind_(std::move(kind)),
+      track_(track),
+      streams_(std::move(streams)),
+      encoded_audio_frame_transformer_(
+          kind_ == "audio"
+              ? sender_->GetEncodedAudioStreamTransformer()->GetBroker()
+              : nullptr),
+      encoded_video_frame_transformer_(
+          kind_ == "video"
+              ? sender_->GetEncodedVideoStreamTransformer()->GetBroker()
+              : nullptr),
+      encoded_audio_packet_transformer_(
+          kind_ == "audio"
+              ? sender_->GetEncodedAudioPacketTransformer()->GetBroker()
+              : nullptr),
+      encoded_video_packet_transformer_(
+          kind_ == "video"
+              ? sender_->GetEncodedVideoPacketTransformer()->GetBroker()
+               : nullptr) {
+  // Current implementation
+}
+```
+
+After the updates to the `RTCRtpSender::setTransform`, it will be able to distinguish which type of `transform` have been provided.
+
+```cpp
+void RTCRtpSender::setTransform(
+    V8UnionRTCRtpScriptTransformOrSFrameTransform* transform,
+    ExceptionState& exception_state) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (transform_ == transform) {
+    return;
+  }
+  
+  if (!transform) {
+    transform_->Detach();
+    transform_ = nullptr;
+    return;
+  }
+
+  transform_ = transform;
+
+  if (transform->IsRTCRtpScriptTransform()) {
+    setUpRTCRtpScriptTransform(transform_->GetAsRTCRtpScriptTransform(), exception_state);
+  }
+
+  if (transform->IsSFrameTransform()) {
+    setUpSFrameTransform(transform_->GetAsSFrameTransform(), exception_state);
+  }
+}
+```
+
+To the `SFrameTransform` and `RTCRtpScriptTransform` both transformers will be provided, so that it could setup a pipeline depending on the request.
+
+For now `setUpSFrameTransform` and `setUpRTCRtpScriptTransform` probably will look like the same. Leaving it as a separate methods for this draft purpose.
+
+```cpp
+void RTCRtpSender::setUpSFrameTransform(
+    SFrameTransform* transform,
+    ExceptionState& exception_state) {
+  if (kind_ == "audio") {
+    transform->CreateAudioUnderlyingSourceAndSink(
+      CrossThreadBindOnce(&RTCRtpSender::UnregisterEncodedAudioStreamCallback,
+                          WrapCrossThreadWeakPersistent(this)),
+          encoded_audio_transformer_,
+          encoded_audio_packet_transformer_);
+      return;
+  } else {
+    transform->CreateVideoUnderlyingSourceAndSink(
+      CrossThreadBindOnce(&RTCRtpSender::UnregisterEncodedVideoStreamCallback,
+                          WrapCrossThreadWeakPersistent(this)),
+      encoded_video_frame_transformer_,
+      encoded_video_packet_transformer_);
+  }
+}
+
+void RTCRtpSender::setUpRTCRtpScriptTransform(
+    RTCRtpScriptTransform* transform,
+    ExceptionState& exception_state) {
+  if (kind_ == "audio") {
+    transform->CreateAudioUnderlyingSourceAndSink(
+      CrossThreadBindOnce(&RTCRtpSender::UnregisterEncodedAudioStreamCallback,
+                          WrapCrossThreadWeakPersistent(this)),
+          encoded_audio_transformer_,
+          encoded_audio_packet_transformer_);
+      return;
+  } else {
+    transform->CreateVideoUnderlyingSourceAndSink(
+      CrossThreadBindOnce(&RTCRtpSender::UnregisterEncodedVideoStreamCallback,
+                          WrapCrossThreadWeakPersistent(this)),
+      encoded_video_frame_transformer_,
+      encoded_video_packet_transformer_);
+  }
+}
+```

--- a/blink-sframe-transform.md
+++ b/blink-sframe-transform.md
@@ -1,0 +1,244 @@
+# Blink SFrameTransform
+
+This document describes how SFrameTransform will be integrated into Blink layer.
+
+## IDL
+
+The IDL definition specifies how `SFrameTransform` is exposed to JavaScript and defines the interface between the JavaScript layer and the C++ Blink implementation. This includes the SFrame operating modes and configuration options.
+
+`third_party/blink/renderer/modules/peerconnection/sframe_transform.idl`
+```idl
+enum SFrameMode {
+  "per-frame",
+  "per-packet",
+};
+
+dictionary SFrameTransformOptions {
+    SFrameMode mode;
+};
+
+[Exposed=(Window,Worker)]
+interface SFrameTransform {
+    [CallWith=ScriptState, RaisesException] constructor(optional SFrameTransformOptions options = {});
+    
+    readonly attribute ReadableStream readable;
+    readonly attribute WritableStream writable;
+};
+```
+
+## SFrameTransform
+
+`SFrameTransform` is the main C++ implementation class that bridges the JavaScript API with the underlying WebRTC transformation infrastructure. It manages the lifecycle of SFrame encryption/decryption operations and handles both stream-based (pipeThrough) and direct assignment usage patterns.
+
+`third_party/blink/renderer/modules/peerconnection/s_frame_transform.h`
+```cpp
+class MODULES_EXPORT SFrameTransform final : public ScriptWrappable {
+  DEFINE_WRAPPERTYPEINFO();
+
+ public:
+  static SFrameTransform* Create(ScriptState* script_state,
+                                 const SFrameTransformOptions* options,
+                                 ExceptionState& exception_state);
+
+  explicit SFrameTransform(ScriptState* script_state,
+                           const SFrameTransformOptions* options,
+                           ExceptionState& exception_state);
+  ~SFrameTransform() override = default;
+
+  // Expose readable/writable for pipeThrough usage
+  ReadableStream* readable() const { return readable_; }
+  WritableStream* writable() const { return writable_; }
+
+  // Called when this transform is assigned to an RTCRtpSender or
+  // RTCRtpReceiver via setTransform().
+  void CreateAudioUnderlyingSourceAndSink(
+      CrossThreadOnceClosure disconnect_callback_source,
+      scoped_refptr<blink::RTCEncodedAudioStreamTransformer::Broker>
+          encoded_audio_frame_transformer,
+      scoped_refptr<blink::RTCEncodedAudioStreamTransformer::Broker>
+          encoded_audio_packet_transformer);
+
+  void CreateVideoUnderlyingSourceAndSink(
+      CrossThreadOnceClosure disconnect_callback_source,
+      scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+          encoded_video_frame_transformer,
+      scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+          encoded_video_packet_transformer);
+
+  void Attach();
+  void Detach();
+  bool HasBeenUsed() const;
+
+  void Trace(Visitor* visitor) const override;
+
+ private:
+  // Streams exposed for pipeThrough usage
+  Member<ReadableStream> readable_;
+  Member<WritableStream> writable_;
+
+  Member<SFrameTransformer> transformer_;
+  
+  // Configuration options
+  Member<SFrameTransformOptions> options_;
+  
+  bool is_attached_ = false;
+  bool is_unused_ = true;
+};
+```
+
+It's most important functions are `CreateAudioUnderlyingSourceAndSink` and `CreateVideoUnderlyingSourceAndSink` as it will be used to create a underlying SFrame transformer which will perform SFrame encryption/decryption on one of the provided `Frame`/`Packet` transformers passthough.
+
+```cpp
+void SFrameTransform::CreateVideoUnderlyingSourceAndSink(
+    CrossThreadOnceClosure disconnect_callback_source,
+    scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+        encoded_video_frame_transformer,
+    scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+        encoded_video_packet_transformer) {
+  if (!video_transformer_) {
+    video_transformer_ = MakeGarbageCollected<SFrameTransformer>();
+  }
+  
+  // Select transformer based on mode
+  scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker> selected_transformer;
+  if (options_ && options_->hasMode() && options_->mode() == V8SFrameMode::Enum::kPerPacket) {
+    selected_transformer = std::move(encoded_video_packet_transformer);
+  } else {
+    selected_transformer = std::move(encoded_video_frame_transformer);
+  }
+  
+  video_transformer_->SetUpVideo(std::move(disconnect_callback_source),
+                                  std::move(selected_transformer));
+}
+```
+
+## SFrameTransformer
+
+`SFrameTransformer` acts as the bridge between Blink's encoded stream transformers and the actual SFrame encryption/decryption logic. It receives encoded frames from the WebRTC pipeline, applies SFrame transformations, and sends the processed frames back to the pipeline. This component manages:
+
+- **Frame callback registration** with WebRTC transformer brokers
+- **Cross-thread communication** for safe frame processing
+- **SFrame encryption/decryption operations** on audio and video frames
+- **Error handling and cleanup** when transforms are detached
+
+```cpp
+class MODULES_EXPORT SFrameTransformer final
+    : public GarbageCollected<SFrameTransformer> {
+ public:
+  SFrameTransformer();
+  ~SFrameTransformer() = default;
+
+  // Set up for audio transformation
+  void SetUpAudio(
+      CrossThreadOnceClosure disconnect_callback_source,
+      scoped_refptr<blink::RTCEncodedAudioStreamTransformer::Broker>
+          encoded_audio_transformer);
+
+  // Set up for video transformation
+  void SetUpVideo(
+      CrossThreadOnceClosure disconnect_callback_source,
+      scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+          encoded_video_transformer);
+
+  // Clear callbacks
+  void Clear();
+
+  void Trace(Visitor* visitor) const {}
+
+ private:
+  // Audio frame transformation (dummy encryption/decryption)
+  void TransformAudioFrame(
+      std::unique_ptr<webrtc::TransformableAudioFrameInterface> frame);
+
+  // Video frame transformation (dummy encryption/decryption)
+  void TransformVideoFrame(
+      std::unique_ptr<webrtc::TransformableVideoFrameInterface> frame);
+
+  // Post the transformed frame back to the sink
+  void SendAudioFrameToSink(
+      std::unique_ptr<webrtc::TransformableAudioFrameInterface> frame);
+  
+  void SendVideoFrameToSink(
+      std::unique_ptr<webrtc::TransformableVideoFrameInterface> frame);
+
+  scoped_refptr<base::SingleThreadTaskRunner> task_runner_;
+  scoped_refptr<blink::RTCEncodedAudioStreamTransformer::Broker>
+      audio_broker_;
+  scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+      video_broker_;
+};
+```
+
+Draft of the methods (To be implemented).
+
+```cpp
+SFrameTransformer::SFrameTransformer()
+    : task_runner_(base::SingleThreadTaskRunner::GetCurrentDefault()) {}
+
+void SFrameTransformer::SetUpAudio(
+    CrossThreadOnceClosure disconnect_callback_source,
+    scoped_refptr<blink::RTCEncodedAudioStreamTransformer::Broker>
+        encoded_audio_transformer) {
+  audio_broker_ = std::move(encoded_audio_transformer);
+
+  // Set up the transformer callback to receive frames from WebRTC
+  audio_broker_->SetTransformerCallback(
+      CrossThreadBindRepeating(&SFrameTransformer::TransformAudioFrame,
+                               WrapCrossThreadPersistent(this)));
+}
+
+void SFrameTransformer::SetUpVideo(
+    CrossThreadOnceClosure disconnect_callback_source,
+    scoped_refptr<blink::RTCEncodedVideoStreamTransformer::Broker>
+        encoded_video_transformer) {
+  video_broker_ = std::move(encoded_video_transformer);
+
+  // Set up the transformer callback to receive frames from WebRTC
+  video_broker_->SetTransformerCallback(
+      CrossThreadBindRepeating(&SFrameTransformer::TransformVideoFrame,
+                               WrapCrossThreadPersistent(this)));
+}
+
+void SFrameTransformer::Clear() {
+  if (audio_broker_) {
+    audio_broker_->ResetTransformerCallback();
+    audio_broker_ = nullptr;
+  }
+  if (video_broker_) {
+    video_broker_->ResetTransformerCallback();
+    video_broker_ = nullptr;
+  }
+}
+
+void SFrameTransformer::TransformAudioFrame(
+    std::unique_ptr<webrtc::TransformableAudioFrameInterface> frame) {
+  if (!frame || !audio_broker_) {
+    return;
+  }
+
+  // Push frame to libwebrtc Transformer
+}
+
+void SFrameTransformer::TransformVideoFrame(
+    std::unique_ptr<webrtc::TransformableVideoFrameInterface> frame) {
+  if (!frame || !video_broker_) {
+    return;
+  }
+
+  // Push frame to libwebrtc Transformer
+}
+
+void SFrameTransformer::SendAudioFrameToSink(
+    std::unique_ptr<webrtc::TransformableAudioFrameInterface> frame) {
+  if (audio_broker_) {
+    audio_broker_->SendFrameToSink(std::move(frame));
+  }
+}
+
+void SFrameTransformer::SendVideoFrameToSink(
+    std::unique_ptr<webrtc::TransformableVideoFrameInterface> frame) {
+  if (video_broker_) {
+    video_broker_->SendFrameToSink(std::move(frame));
+  }
+}
+```

--- a/negotiation-trigger-proposals.md
+++ b/negotiation-trigger-proposals.md
@@ -155,440 +155,90 @@ class VideoRtpReceiver : public RtpReceiverInternal {
 };
 ```
 
-## Proposal 2: FrameTransformerNegotiationObserver Pattern (Archived)
+#### Blink
 
-### Motivation
+##### RTCRtpSenderInternal
 
-This archived approach used an **observer/push pattern** where transformers actively request SDP features through a callback interface.
-
-## Proposal 2: FrameTransformerNegotiationObserver Pattern (Archived)
-
-### Motivation
-
-This archived approach used an **observer/push pattern** where transformers actively request SDP features through a callback interface.
-
-With an SFrame feature implemented through transformers, it requires an ability to trigger additional actions at the libWebRTC level for it to work correctly, such as:
-* **SDP Modification**: Add `a=sframe` attribute to the m-line
-* **Packetizer Selection**: Use SFrame-specific packetizer/depacketizer
-
-One approach is to extend `FrameTransformerInterface` with an ability to register an observer with a predefined list of features that can be signaled.
-
-### API Design
-
-#### SdpFeature Enum
-
-Define an enumeration of SDP features that transformers can request:
+Currently:
 
 ```cpp
-enum class SdpFeature {
-  // Secure Frame (SFrame) encryption
-  // Adds "a=sframe" to the SDP
-  kSFrame,
-};
-```
+RTCRtpSenderInternal(
+      webrtc::scoped_refptr<webrtc::PeerConnectionInterface>
+          native_peer_connection,
+      scoped_refptr<blink::WebRtcMediaStreamTrackAdapterMap> track_map,
+      RtpSenderState state)
+      : native_peer_connection_(std::move(native_peer_connection)),
+        track_map_(std::move(track_map)),
+        main_task_runner_(state.main_task_runner()),
+        signaling_task_runner_(state.signaling_task_runner()),
+        webrtc_sender_(state.webrtc_sender()),
+        state_(std::move(state)) {
+    DCHECK(track_map_);
+    DCHECK(state_.is_initialized());
 
-#### FrameTransformerNegotiationObserver Interface
-
-The observer interface that RTP senders/receivers implement to handle negotiation requests:
-
-```cpp
-class FrameTransformerNegotiationObserver {
- public:
-  virtual ~FrameTransformerNegotiationObserver() = default;
-
-  // Called when the transformer wants to enable a predefined SDP feature.
-  // This automatically triggers SDP renegotiation.
-  // Parameters:
-  //   feature - The predefined feature to enable (e.g., SdpFeature::kSFrame)
-  virtual void OnSdpAttributeRequest(SdpFeature feature) = 0;
-};
-```
-
-#### FrameTransformerInterface Extension
-
-Extend `FrameTransformerInterface` to support observer registration:
-
-```cpp
-class FrameTransformerInterface : public RefCountInterface {
- public:
-  // Register an observer to receive negotiation requests
-  virtual void SetNegotiationObserver(
-      FrameTransformerNegotiationObserver* observer) {}
-
-  // Unregister the current observer
-  virtual void UnsetNegotiationObserver() {}
-
- protected:
-  ~FrameTransformerInterface() override = default;
-};
-```
-
-### Implementation in SFrame Transformers
-
-#### SFrameTransformerBase
-
-The base class implements observer registration and triggers negotiation when needed:
-
-```cpp
-class SFrameTransformerBase : public SFrameTransformerInterface {
- public:
-  SFrameTransformerBase();
-
-  // SFrameTransformerInterface implementation
-  void SetEncryptionKey(const std::vector<uint8_t>& key) override;
-  std::vector<uint8_t> GetEncryptionKey() const override;
-
-  // FrameTransformerInterface implementation
-  void SetNegotiationObserver(
-      FrameTransformerNegotiationObserver* observer) override;
-  void UnsetNegotiationObserver() override;
-
- protected:
-  void RequestSdpFeature(SdpFeature feature);
-
- private:
-  FrameTransformerNegotiationObserver* negotiation_observer_ = nullptr;
-};
-```
-
-Implementation:
-
-```cpp
-void SFrameTransformerBase::SetNegotiationObserver(
-    FrameTransformerNegotiationObserver* observer) {
-  negotiation_observer_ = observer;
-  
-  // Immediately request SFrame SDP attribute when observer is set
-  if (negotiation_observer_) {
-    RequestSdpFeature(SdpFeature::kSFrame);
+    if (webrtc_sender_->media_type() == webrtc::MediaType::AUDIO) {
+      // Frame-level transformer
+      encoded_audio_transformer_ =
+          std::make_unique<RTCEncodedAudioStreamTransformer>(main_task_runner_);
+      webrtc_sender_->SetFrameTransformer(
+          encoded_audio_transformer_->Delegate());
+      
+      // Packet-level transformer
+      encoded_audio_packet_transformer_ =
+          std::make_unique<RTCEncodedAudioStreamTransformer>(main_task_runner_);
+      webrtc_sender_->SetPacketTransformer(
+          encoded_audio_packet_transformer_->Delegate(), {});
+    } else {
+      CHECK(webrtc_sender_->media_type() == webrtc::MediaType::VIDEO);
+      // Frame-level transformer
+      encoded_video_transformer_ =
+          std::make_unique<RTCEncodedVideoStreamTransformer>(
+              main_task_runner_, /*metronome=*/nullptr);
+      webrtc_sender_->SetFrameTransformer(
+          encoded_video_transformer_->Delegate());
+      
+      // Packet-level transformer
+      encoded_video_packet_transformer_ =
+          std::make_unique<RTCEncodedVideoStreamTransformer>(
+              main_task_runner_, /*metronome=*/nullptr);
+      webrtc_sender_->SetPacketTransformer(
+          encoded_video_packet_transformer_->Delegate(), {});
+    }
   }
-}
+```
 
-void SFrameTransformerBase::UnsetNegotiationObserver() {
-  negotiation_observer_ = nullptr;
-}
+With new recreate method:
 
-void SFrameTransformerBase::RequestSdpFeature(SdpFeature feature) {
-  if (negotiation_observer_) {
-    negotiation_observer_->OnSdpAttributeRequest(feature);
+```cpp
+void RTCRtpSenderInternal::MaybeRecreateFrameTransformers() {
+  if (encoded_video_transformer_) {
+    // Recreate frame transformer
+    auto features = encoded_video_transformer_->GetTransformationFeatures();
+
+    webrtc_sender_->SetFrameTransformer(
+      encoded_video_transformer_->Delegate(), features);
+  }
+    
+  // Recreate packet transformer
+  if (encoded_video_packet_transformer_) {
+    auto features = encoded_video_packet_transformer_->GetTransformationFeatures();
+
+    webrtc_sender_->SetPacketTransformer(
+      encoded_video_packet_transformer_->Delegate(), features);
   }
 }
 ```
 
-## Integration with RTP Senders
-
-### RtpSenderBase Implementation
-
-`RtpSenderBase` implements `FrameTransformerNegotiationObserver` to handle negotiation requests from transformers:
+##### RTCRtpSender
 
 ```cpp
-class RtpSenderBase : public RtpSenderInternal,
-                      public FrameTransformerHost,
-                      public FrameTransformerNegotiationObserver {
- public:
-  // FrameTransformerHost implementation
-  void SetFrameTransformer(
-      scoped_refptr<FrameTransformerInterface> frame_transformer) override;
+void RTCRtpSender::setTransform(
+    V8UnionRTCRtpScriptTransformOrSFrameTransform* transform,
+    ExceptionState& exception_state) {
+  /// Perform creation of transformers
 
-  void SetPacketTransformer(
-      scoped_refptr<FrameTransformerInterface> packet_transformer) override;
-
-  // FrameTransformerNegotiationObserver implementation
-  void OnSdpAttributeRequest(SdpFeature feature) override;
-
- private:
-  // Stored transformer references
-  scoped_refptr<FrameTransformerInterface> frame_transformer_;
-  scoped_refptr<FrameTransformerInterface> packet_transformer_;
-  
-  // Requested SDP features from transformers
-  std::vector<SdpFeature> transformer_sdp_features_;
-  
-  // Callback to trigger SDP renegotiation
-  OnNegotiationNeededCallback on_negotiation_needed_;
-};
-```
-
-### Transformer Registration and Negotiation
-
-```cpp
-void RtpSenderBase::SetFrameTransformer(
-    scoped_refptr<FrameTransformerInterface> frame_transformer) {
-  // Unregister from old transformer if present
-  if (frame_transformer_) {
-    frame_transformer_->UnsetNegotiationObserver();
-  }
-
-  frame_transformer_ = std::move(frame_transformer);
-
-  // Register as negotiation observer
-  if (frame_transformer_) {
-    frame_transformer_->SetNegotiationObserver(this);
-  }
-
-  if (media_channel_ && ssrc_ && !stopped_) {
-    worker_thread_->BlockingCall([&] {
-      media_channel_->SetEncoderToPacketizerFrameTransformer(
-          ssrc_, frame_transformer_);
-    });
+  if (sender_) {
+    sender_->MaybeRecreateFrameTransformers();
   }
 }
-
-void RtpSenderBase::SetPacketTransformer(
-    scoped_refptr<FrameTransformerInterface> packet_transformer) {
-  // Unregister from old transformer if present
-  if (packet_transformer_) {
-    packet_transformer_->UnsetNegotiationObserver();
-  }
-
-  packet_transformer_ = std::move(packet_transformer);
-
-  // Register as negotiation observer
-  if (packet_transformer_) {
-    packet_transformer_->SetNegotiationObserver(this);
-  }
-
-  if (media_channel_ && ssrc_ != 0) {
-    worker_thread_->BlockingCall([&] {
-      media_channel_->SetPacketTransformer(ssrc_, packet_transformer_);
-    });
-  }
-}
-
-void RtpSenderBase::OnSdpAttributeRequest(SdpFeature feature) {
-  transformer_sdp_features_.push_back(feature);
-  
-  // Trigger SDP renegotiation
-  if (on_negotiation_needed_) {
-    on_negotiation_needed_();
-  }
-}
-```
-
-### Sequence Diagram: Frame-Level Transformer with Negotiation
-
-```mermaid
-sequenceDiagram
-    participant User as Application/User Code
-    participant API as RtpSenderInterface
-    participant Base as RtpSenderBase
-    participant Transformer as SFrameFrameTransformer
-    participant Delegate as RtpSenderVideoFrameTransformerDelegate
-
-    Note over User, Delegate: Frame-Level SFrame Transformer with Negotiation
-
-    User->>User: Create SFrame Frame Transformer
-    Note right of User: auto transformer =<br/>make_ref_counted<SFrameFrameTransformer>()
-
-    User->>Transformer: SetEncryptionKey(key)
-    
-    User->>API: SetFrameTransformer(transformer)
-    API->>Base: SetFrameTransformer(transformer)
-    
-    Base->>Transformer: SetNegotiationObserver(this)
-    Note over Base, Transformer: Register for SDP negotiations
-    
-    Transformer->>Base: OnSdpAttributeRequest(SdpFeature::kSFrame)
-    Note over Transformer, Base: Request SFrame SDP attribute
-    
-    Base->>Base: on_negotiation_needed_callback_()
-    Note over Base: Trigger SDP renegotiation
-    
-    Base->>Delegate: Create RtpSenderVideoFrameTransformerDelegate
-    Note over Base, Delegate: Delegate manages frame transformation
-
-    Note over User, Delegate: Initialization Complete with Negotiation
-```
-
-### Sequence Diagram: Packet-Level Transformer with Negotiation
-
-```mermaid
-sequenceDiagram
-    participant User as Application/User Code
-    participant API as RtpSenderInterface
-    participant Base as RtpSenderBase
-    participant Transformer as SFramePacketTransformer
-    participant Delegate as RtpSenderVideoPacketTransformerDelegate
-
-    Note over User, Delegate: Packet-Level SFrame Transformer with Negotiation
-
-    User->>User: Create SFrame Packet Transformer
-    Note right of User: auto transformer =<br/>make_ref_counted<SFramePacketTransformer>()
-
-    User->>Transformer: SetEncryptionKey(key)
-    
-    User->>API: SetPacketTransformer(transformer)
-    API->>Base: SetPacketTransformer(transformer)
-    
-    Base->>Transformer: SetNegotiationObserver(this)
-    Note over Base, Transformer: Register for SDP negotiations
-    
-    Transformer->>Base: OnSdpAttributeRequest(SdpFeature::kSFrame)
-    Note over Transformer, Base: Request SFrame SDP attribute
-    
-    Base->>Base: on_negotiation_needed_callback_()
-    Note over Base: Trigger SDP renegotiation
-    
-    Base->>Delegate: Create RtpSenderVideoPacketTransformerDelegate
-    Note over Base, Delegate: Delegate manages packet transformation
-
-    Note over User, Delegate: Initialization Complete with Negotiation
-```
-
-## Integration with RTP Receivers
-
-### VideoRtpReceiver Implementation
-
-`VideoRtpReceiver` implements `FrameTransformerNegotiationObserver` to handle negotiation requests from transformers:
-
-```cpp
-class VideoRtpReceiver : public RtpReceiverInternal,
-                         public FrameTransformerNegotiationObserver {
- public:
-  void SetFrameTransformer(
-      scoped_refptr<FrameTransformerInterface> frame_transformer) override;
-
-  void SetPacketTransformer(
-      scoped_refptr<FrameTransformerInterface> packet_transformer) override;
-
-  // FrameTransformerNegotiationObserver implementation
-  void OnSdpAttributeRequest(SdpFeature feature) override;
-
- private:
-  // Stored transformer references
-  scoped_refptr<FrameTransformerInterface> frame_transformer_
-      RTC_GUARDED_BY(worker_thread_);
-  scoped_refptr<FrameTransformerInterface> packet_transformer_
-      RTC_GUARDED_BY(worker_thread_);
-
-  // Callback to trigger SDP renegotiation
-  OnNegotiationNeededCallback on_negotiation_needed_;
-};
-```
-
-### Transformer Registration and Negotiation
-
-```cpp
-void VideoRtpReceiver::SetFrameTransformer(
-    scoped_refptr<FrameTransformerInterface> frame_transformer) {
-  RTC_DCHECK_RUN_ON(worker_thread_);
-  
-  // Unregister from old transformer
-  if (frame_transformer_) {
-    frame_transformer_->UnsetNegotiationObserver();
-  }
-  
-  frame_transformer_ = std::move(frame_transformer);
-  
-  // Register with new transformer
-  if (frame_transformer_) {
-    frame_transformer_->SetNegotiationObserver(this);
-  }
-
-  if (media_channel_) {
-    media_channel_->SetDepacketizerToDecoderFrameTransformer(
-        signaled_ssrc_.value_or(0), frame_transformer_);
-  }
-}
-
-void VideoRtpReceiver::SetPacketTransformer(
-    scoped_refptr<FrameTransformerInterface> packet_transformer) {
-  RTC_DCHECK_RUN_ON(worker_thread_);
-  
-  // Unregister from old transformer
-  if (packet_transformer_) {
-    packet_transformer_->UnsetNegotiationObserver();
-  }
-  
-  packet_transformer_ = std::move(packet_transformer);
-  
-  // Register with new transformer
-  if (packet_transformer_) {
-    packet_transformer_->SetNegotiationObserver(this);
-  }
-
-  if (media_channel_) {
-    media_channel_->SetPacketTransformer(signaled_ssrc_.value_or(0),
-                                         packet_transformer_);
-  }
-}
-
-void VideoRtpReceiver::OnSdpAttributeRequest(SdpFeature feature) {
-  RTC_DCHECK_RUN_ON(worker_thread_);
-  
-  // Trigger SDP renegotiation
-  if (on_negotiation_needed_) {
-    on_negotiation_needed_();
-  }
-}
-```
-
-### Sequence Diagram: Frame-Level Transformer with Negotiation
-
-```mermaid
-sequenceDiagram
-    participant User as Application/User Code
-    participant API as RtpReceiverInterface
-    participant Base as VideoRtpReceiver
-    participant Transformer as SFrameFrameTransformer
-    participant Delegate as RtpVideoStreamReceiverFrameTransformerDelegate
-
-    Note over User, Delegate: Frame-Level SFrame Transformer with Negotiation
-
-    User->>User: Create SFrame Frame Transformer
-    Note right of User: auto transformer =<br/>make_ref_counted<SFrameFrameTransformer>()
-
-    User->>Transformer: SetDecryptionKey(key)
-    
-    User->>API: SetDepacketizerToDecoderFrameTransformer(transformer)
-    API->>Base: SetDepacketizerToDecoderFrameTransformer(transformer)
-    
-    Base->>Transformer: SetNegotiationObserver(this)
-    Note over Base, Transformer: Register for SDP negotiations
-    
-    Transformer->>Base: OnSdpAttributeRequest(SdpFeature::kSFrame)
-    Note over Transformer, Base: Request SFrame SDP attribute
-    
-    Base->>Base: on_negotiation_needed_callback_()
-    Note over Base: Trigger SDP renegotiation
-    
-    Base->>Delegate: Create RtpVideoStreamReceiverFrameTransformerDelegate
-    Note over Base, Delegate: Delegate manages frame transformation
-
-    Note over User, Delegate: Initialization Complete with Negotiation
-```
-
-### Sequence Diagram: Packet-Level Transformer with Negotiation
-
-```mermaid
-sequenceDiagram
-    participant User as Application/User Code
-    participant API as RtpReceiverInterface
-    participant Base as VideoRtpReceiver
-    participant Transformer as SFramePacketTransformer
-    participant Delegate as RtpVideoStreamReceiverPacketTransformerDelegate
-
-    Note over User, Delegate: Packet-Level SFrame Transformer with Negotiation
-
-    User->>User: Create SFrame Packet Transformer
-    Note right of User: auto transformer =<br/>make_ref_counted<SFramePacketTransformer>()
-
-    User->>Transformer: SetDecryptionKey(key)
-    
-    User->>API: SetPacketTransformer(transformer)
-    API->>Base: SetPacketTransformer(transformer)
-    
-    Base->>Transformer: SetNegotiationObserver(this)
-    Note over Base, Transformer: Register for SDP negotiations
-    
-    Transformer->>Base: OnSdpAttributeRequest(SdpFeature::kSFrame)
-    Note over Transformer, Base: Request SFrame SDP attribute
-    
-    Base->>Base: on_negotiation_needed_callback_()
-    Note over Base: Trigger SDP renegotiation
-    
-    Base->>Delegate: Create RtpVideoStreamReceiverPacketTransformerDelegate
-    Note over Base, Delegate: Delegate manages packet transformation
-
-    Note over User, Delegate: Initialization Complete with Negotiation
 ```

--- a/negotiation-trigger-proposals.md
+++ b/negotiation-trigger-proposals.md
@@ -1,0 +1,675 @@
+# SFrame Negotiation Trigger Proposals
+
+This document contains various proposals for how SFrame transformers can trigger SDP negotiation and modify SDP attributes.
+
+## Overview
+
+When implementing SFrame encryption through frame transformers, there's a need for transformers to:
+1. Signal that specific SDP attributes should be added (e.g., `a=sframe`)
+2. Trigger SDP renegotiation when transformers are attached
+3. Control which packetizer/depacketizer is used based on the encryption mode
+
+### Comparison of Approaches
+
+| Aspect | Proposal 1: Features Parameter | Proposal 2: Observer Pattern |
+|--------|-------------------------------|------------------------------|
+| **Pattern** | Parameter-passing (pull) | Observer/callback (push) |
+| **Control** | Application explicitly specifies features | Transformer requests features via callback |
+| **Complexity** | Simple transformer implementation | Transformers need negotiation logic |
+| **Flexibility** | Features can be changed independently | Transformers control their own requirements |
+| **Testability** | Easy to test with explicit parameters | Requires observer mock/stub setup |
+| **Timing** | Features specified at attachment time | Features can be requested dynamically |
+| **Thread Safety** | Clear ownership model | Requires careful callback threading |
+| **API Surface** | Extends SetFrameTransformer signature | Adds new observer interface |
+| **Discovery** | Application must know required features | Transformers declare their needs |
+
+## Proposal 1: Features Parameter Approach
+
+### Motivation
+
+This approach uses a **parameter-passing pattern** where the application explicitly specifies which SDP features should be associated with a transformer when attaching it to a sender/receiver. This keeps the transformer implementation simple and gives the application explicit control over feature negotiation.
+
+### API Design
+
+#### SdpFeature Enum
+
+Define an enumeration of SDP features that can be requested:
+
+```cpp
+enum class SdpFeature {
+  // Secure Frame (SFrame) encryption
+  // Adds "a=sframe" to the SDP
+  kSFrame,
+};
+```
+
+#### FrameTransformerHost Interface
+
+The base interface that RTP senders/receivers implement to accept transformers with features:
+
+```cpp
+class FrameTransformerHost {
+ public:
+  virtual ~FrameTransformerHost() {}
+  
+  virtual void SetFrameTransformer(
+      scoped_refptr<FrameTransformerInterface> frame_transformer,
+      const std::vector<SdpFeature>& features = {}) = 0;
+      
+  virtual void SetPacketTransformer(
+      scoped_refptr<FrameTransformerInterface> packet_transformer,
+      const std::vector<SdpFeature>& features = {}) = 0;
+};
+```
+
+#### RtpSenderInterface / RtpReceiverInterface
+
+Extended to accept features parameter:
+
+```cpp
+class RtpSenderInterface : public FrameTransformerHost {
+ public:
+  void SetFrameTransformer(
+      scoped_refptr<FrameTransformerInterface> frame_transformer,
+      const std::vector<SdpFeature>& features = {}) override;
+      
+  void SetPacketTransformer(
+      scoped_refptr<FrameTransformerInterface> packet_transformer,
+      const std::vector<SdpFeature>& features = {}) override;
+};
+```
+
+### Implementation
+
+#### RtpSenderBase
+
+Stores features and triggers negotiation when they change:
+
+```cpp
+class RtpSenderBase : public RtpSenderInternal {
+ public:
+  void SetFrameTransformer(
+      scoped_refptr<FrameTransformerInterface> frame_transformer,
+      const std::vector<SdpFeature>& features) override {
+    RTC_DCHECK_RUN_ON(signaling_thread_);
+    
+    // Check if features have changed
+    bool features_changed = (frame_transformer_features_ != features);
+    
+    frame_transformer_ = std::move(frame_transformer);
+    frame_transformer_features_ = features;
+    
+    // Trigger negotiation if features changed
+    if (features_changed && on_negotiation_needed_) {
+      on_negotiation_needed_();
+    }
+    
+    // Set transformer on worker thread
+    if (media_channel_ && ssrc_ && !stopped_) {
+      worker_thread_->BlockingCall([&] {
+        media_channel_->SetEncoderToPacketizerFrameTransformer(
+            ssrc_, frame_transformer_);
+      });
+    }
+  }
+
+ private:
+  std::vector<SdpFeature> frame_transformer_features_;
+  std::vector<SdpFeature> packet_transformer_features_;
+  OnNegotiationNeededCallback on_negotiation_needed_;
+};
+```
+
+#### VideoRtpReceiver
+
+Similar implementation for receivers:
+
+```cpp
+class VideoRtpReceiver : public RtpReceiverInternal {
+ public:
+  void SetFrameTransformer(
+      scoped_refptr<FrameTransformerInterface> frame_transformer,
+      const std::vector<SdpFeature>& features) override {
+    RTC_DCHECK_RUN_ON(&signaling_thread_checker_);
+    
+    // Store features on signaling thread
+    frame_transformer_features_ = features;
+    
+    // Set transformer on worker thread
+    worker_thread_->BlockingCall([this, frame_transformer = std::move(frame_transformer)]() mutable {
+      RTC_DCHECK_RUN_ON(worker_thread_);
+      frame_transformer_ = std::move(frame_transformer);
+      
+      if (media_channel_) {
+        media_channel_->SetDepacketizerToDecoderFrameTransformer(
+            signaled_ssrc_.value_or(0), frame_transformer_);
+      }
+    });
+  }
+
+ private:
+  std::vector<SdpFeature> frame_transformer_features_
+      RTC_GUARDED_BY(signaling_thread_checker_);
+};
+```
+
+### Usage Example
+
+```cpp
+// Create SFrame transformer
+auto sframe_transformer = CreateSFrameTransformer();
+
+// Attach to sender with SFrame feature
+sender->SetPacketTransformer(sframe_transformer, {SdpFeature::kSFrame});
+
+// This triggers negotiation needed event, which causes:
+// 1. PeerConnection to call CreateOffer/CreateAnswer
+// 2. SDP generation to check transformer features
+// 3. Add "a=sframe" attribute to m-line if kSFrame feature present
+```
+
+### Advantages
+
+1. **Explicit Control**: Application has full visibility and control over which features are enabled
+2. **Simple Transformer Implementation**: Transformers don't need to know about negotiation
+3. **Testable**: Easy to test feature changes and negotiation triggers
+4. **Flexible**: Can attach transformers without features, or change features later
+5. **Thread-Safe**: Clear ownership - features stored on signaling thread, transformers on worker thread
+
+### Disadvantages
+
+1. **Application Responsibility**: Application must know which features to request
+2. **Timing**: Application must coordinate transformer attachment with feature specification
+3. **No Dynamic Discovery**: Transformers can't dynamically request features based on runtime state
+
+### Integration Points
+
+#### SDP Offer/Answer Generation
+
+When generating SDP, check sender/receiver features:
+
+```cpp
+// In MediaSessionDescriptionFactory
+for (auto& sender : transceivers->senders()) {
+  const auto& features = sender->GetTransformerFeatures();
+  
+  if (std::find(features.begin(), features.end(), 
+                SdpFeature::kSFrame) != features.end()) {
+    // Add a=sframe attribute to media description
+    media_desc->AddAttribute("sframe", "");
+  }
+}
+```
+
+#### Proxy Support
+
+Proxy classes updated to handle features parameter:
+
+```cpp
+// In rtp_sender_proxy.h
+PROXY_METHOD2(void,
+              SetFrameTransformer,
+              scoped_refptr<FrameTransformerInterface>,
+              const std::vector<SdpFeature>&)
+```
+
+## Proposal 2: FrameTransformerNegotiationObserver Pattern (Archived)
+
+### Motivation
+
+This archived approach used an **observer/push pattern** where transformers actively request SDP features through a callback interface.
+
+## Proposal 2: FrameTransformerNegotiationObserver Pattern (Archived)
+
+### Motivation
+
+This archived approach used an **observer/push pattern** where transformers actively request SDP features through a callback interface.
+
+With an SFrame feature implemented through transformers, it requires an ability to trigger additional actions at the libWebRTC level for it to work correctly, such as:
+* **SDP Modification**: Add `a=sframe` attribute to the m-line
+* **Packetizer Selection**: Use SFrame-specific packetizer/depacketizer
+
+One approach is to extend `FrameTransformerInterface` with an ability to register an observer with a predefined list of features that can be signaled.
+
+### API Design
+
+#### SdpFeature Enum
+
+Define an enumeration of SDP features that transformers can request:
+
+```cpp
+enum class SdpFeature {
+  // Secure Frame (SFrame) encryption
+  // Adds "a=sframe" to the SDP
+  kSFrame,
+};
+```
+
+#### FrameTransformerNegotiationObserver Interface
+
+The observer interface that RTP senders/receivers implement to handle negotiation requests:
+
+```cpp
+class FrameTransformerNegotiationObserver {
+ public:
+  virtual ~FrameTransformerNegotiationObserver() = default;
+
+  // Called when the transformer wants to enable a predefined SDP feature.
+  // This automatically triggers SDP renegotiation.
+  // Parameters:
+  //   feature - The predefined feature to enable (e.g., SdpFeature::kSFrame)
+  virtual void OnSdpAttributeRequest(SdpFeature feature) = 0;
+};
+```
+
+#### FrameTransformerInterface Extension
+
+Extend `FrameTransformerInterface` to support observer registration:
+
+```cpp
+class FrameTransformerInterface : public RefCountInterface {
+ public:
+  // Register an observer to receive negotiation requests
+  virtual void SetNegotiationObserver(
+      FrameTransformerNegotiationObserver* observer) {}
+
+  // Unregister the current observer
+  virtual void UnsetNegotiationObserver() {}
+
+ protected:
+  ~FrameTransformerInterface() override = default;
+};
+```
+
+### Implementation in SFrame Transformers
+
+#### SFrameTransformerBase
+
+The base class implements observer registration and triggers negotiation when needed:
+
+```cpp
+class SFrameTransformerBase : public SFrameTransformerInterface {
+ public:
+  SFrameTransformerBase();
+
+  // SFrameTransformerInterface implementation
+  void SetEncryptionKey(const std::vector<uint8_t>& key) override;
+  std::vector<uint8_t> GetEncryptionKey() const override;
+
+  // FrameTransformerInterface implementation
+  void SetNegotiationObserver(
+      FrameTransformerNegotiationObserver* observer) override;
+  void UnsetNegotiationObserver() override;
+
+ protected:
+  void RequestSdpFeature(SdpFeature feature);
+
+ private:
+  FrameTransformerNegotiationObserver* negotiation_observer_ = nullptr;
+};
+```
+
+Implementation:
+
+```cpp
+void SFrameTransformerBase::SetNegotiationObserver(
+    FrameTransformerNegotiationObserver* observer) {
+  negotiation_observer_ = observer;
+  
+  // Immediately request SFrame SDP attribute when observer is set
+  if (negotiation_observer_) {
+    RequestSdpFeature(SdpFeature::kSFrame);
+  }
+}
+
+void SFrameTransformerBase::UnsetNegotiationObserver() {
+  negotiation_observer_ = nullptr;
+}
+
+void SFrameTransformerBase::RequestSdpFeature(SdpFeature feature) {
+  if (negotiation_observer_) {
+    negotiation_observer_->OnSdpAttributeRequest(feature);
+  }
+}
+```
+
+## Integration with RTP Senders
+
+### RtpSenderBase Implementation
+
+`RtpSenderBase` implements `FrameTransformerNegotiationObserver` to handle negotiation requests from transformers:
+
+```cpp
+class RtpSenderBase : public RtpSenderInternal,
+                      public FrameTransformerHost,
+                      public FrameTransformerNegotiationObserver {
+ public:
+  // FrameTransformerHost implementation
+  void SetFrameTransformer(
+      scoped_refptr<FrameTransformerInterface> frame_transformer) override;
+
+  void SetPacketTransformer(
+      scoped_refptr<FrameTransformerInterface> packet_transformer) override;
+
+  // FrameTransformerNegotiationObserver implementation
+  void OnSdpAttributeRequest(SdpFeature feature) override;
+
+ private:
+  // Stored transformer references
+  scoped_refptr<FrameTransformerInterface> frame_transformer_;
+  scoped_refptr<FrameTransformerInterface> packet_transformer_;
+  
+  // Requested SDP features from transformers
+  std::vector<SdpFeature> transformer_sdp_features_;
+  
+  // Callback to trigger SDP renegotiation
+  OnNegotiationNeededCallback on_negotiation_needed_;
+};
+```
+
+### Transformer Registration and Negotiation
+
+```cpp
+void RtpSenderBase::SetFrameTransformer(
+    scoped_refptr<FrameTransformerInterface> frame_transformer) {
+  // Unregister from old transformer if present
+  if (frame_transformer_) {
+    frame_transformer_->UnsetNegotiationObserver();
+  }
+
+  frame_transformer_ = std::move(frame_transformer);
+
+  // Register as negotiation observer
+  if (frame_transformer_) {
+    frame_transformer_->SetNegotiationObserver(this);
+  }
+
+  if (media_channel_ && ssrc_ && !stopped_) {
+    worker_thread_->BlockingCall([&] {
+      media_channel_->SetEncoderToPacketizerFrameTransformer(
+          ssrc_, frame_transformer_);
+    });
+  }
+}
+
+void RtpSenderBase::SetPacketTransformer(
+    scoped_refptr<FrameTransformerInterface> packet_transformer) {
+  // Unregister from old transformer if present
+  if (packet_transformer_) {
+    packet_transformer_->UnsetNegotiationObserver();
+  }
+
+  packet_transformer_ = std::move(packet_transformer);
+
+  // Register as negotiation observer
+  if (packet_transformer_) {
+    packet_transformer_->SetNegotiationObserver(this);
+  }
+
+  if (media_channel_ && ssrc_ != 0) {
+    worker_thread_->BlockingCall([&] {
+      media_channel_->SetPacketTransformer(ssrc_, packet_transformer_);
+    });
+  }
+}
+
+void RtpSenderBase::OnSdpAttributeRequest(SdpFeature feature) {
+  transformer_sdp_features_.push_back(feature);
+  
+  // Trigger SDP renegotiation
+  if (on_negotiation_needed_) {
+    on_negotiation_needed_();
+  }
+}
+```
+
+### Sequence Diagram: Frame-Level Transformer with Negotiation
+
+```mermaid
+sequenceDiagram
+    participant User as Application/User Code
+    participant API as RtpSenderInterface
+    participant Base as RtpSenderBase
+    participant Transformer as SFrameFrameTransformer
+    participant Delegate as RtpSenderVideoFrameTransformerDelegate
+
+    Note over User, Delegate: Frame-Level SFrame Transformer with Negotiation
+
+    User->>User: Create SFrame Frame Transformer
+    Note right of User: auto transformer =<br/>make_ref_counted<SFrameFrameTransformer>()
+
+    User->>Transformer: SetEncryptionKey(key)
+    
+    User->>API: SetFrameTransformer(transformer)
+    API->>Base: SetFrameTransformer(transformer)
+    
+    Base->>Transformer: SetNegotiationObserver(this)
+    Note over Base, Transformer: Register for SDP negotiations
+    
+    Transformer->>Base: OnSdpAttributeRequest(SdpFeature::kSFrame)
+    Note over Transformer, Base: Request SFrame SDP attribute
+    
+    Base->>Base: on_negotiation_needed_callback_()
+    Note over Base: Trigger SDP renegotiation
+    
+    Base->>Delegate: Create RtpSenderVideoFrameTransformerDelegate
+    Note over Base, Delegate: Delegate manages frame transformation
+
+    Note over User, Delegate: Initialization Complete with Negotiation
+```
+
+### Sequence Diagram: Packet-Level Transformer with Negotiation
+
+```mermaid
+sequenceDiagram
+    participant User as Application/User Code
+    participant API as RtpSenderInterface
+    participant Base as RtpSenderBase
+    participant Transformer as SFramePacketTransformer
+    participant Delegate as RtpSenderVideoPacketTransformerDelegate
+
+    Note over User, Delegate: Packet-Level SFrame Transformer with Negotiation
+
+    User->>User: Create SFrame Packet Transformer
+    Note right of User: auto transformer =<br/>make_ref_counted<SFramePacketTransformer>()
+
+    User->>Transformer: SetEncryptionKey(key)
+    
+    User->>API: SetPacketTransformer(transformer)
+    API->>Base: SetPacketTransformer(transformer)
+    
+    Base->>Transformer: SetNegotiationObserver(this)
+    Note over Base, Transformer: Register for SDP negotiations
+    
+    Transformer->>Base: OnSdpAttributeRequest(SdpFeature::kSFrame)
+    Note over Transformer, Base: Request SFrame SDP attribute
+    
+    Base->>Base: on_negotiation_needed_callback_()
+    Note over Base: Trigger SDP renegotiation
+    
+    Base->>Delegate: Create RtpSenderVideoPacketTransformerDelegate
+    Note over Base, Delegate: Delegate manages packet transformation
+
+    Note over User, Delegate: Initialization Complete with Negotiation
+```
+
+## Integration with RTP Receivers
+
+### VideoRtpReceiver Implementation
+
+`VideoRtpReceiver` implements `FrameTransformerNegotiationObserver` to handle negotiation requests from transformers:
+
+```cpp
+class VideoRtpReceiver : public RtpReceiverInternal,
+                         public FrameTransformerNegotiationObserver {
+ public:
+  void SetFrameTransformer(
+      scoped_refptr<FrameTransformerInterface> frame_transformer) override;
+
+  void SetPacketTransformer(
+      scoped_refptr<FrameTransformerInterface> packet_transformer) override;
+
+  // FrameTransformerNegotiationObserver implementation
+  void OnSdpAttributeRequest(SdpFeature feature) override;
+
+ private:
+  // Stored transformer references
+  scoped_refptr<FrameTransformerInterface> frame_transformer_
+      RTC_GUARDED_BY(worker_thread_);
+  scoped_refptr<FrameTransformerInterface> packet_transformer_
+      RTC_GUARDED_BY(worker_thread_);
+
+  // Callback to trigger SDP renegotiation
+  OnNegotiationNeededCallback on_negotiation_needed_;
+};
+```
+
+### Transformer Registration and Negotiation
+
+```cpp
+void VideoRtpReceiver::SetFrameTransformer(
+    scoped_refptr<FrameTransformerInterface> frame_transformer) {
+  RTC_DCHECK_RUN_ON(worker_thread_);
+  
+  // Unregister from old transformer
+  if (frame_transformer_) {
+    frame_transformer_->UnsetNegotiationObserver();
+  }
+  
+  frame_transformer_ = std::move(frame_transformer);
+  
+  // Register with new transformer
+  if (frame_transformer_) {
+    frame_transformer_->SetNegotiationObserver(this);
+  }
+
+  if (media_channel_) {
+    media_channel_->SetDepacketizerToDecoderFrameTransformer(
+        signaled_ssrc_.value_or(0), frame_transformer_);
+  }
+}
+
+void VideoRtpReceiver::SetPacketTransformer(
+    scoped_refptr<FrameTransformerInterface> packet_transformer) {
+  RTC_DCHECK_RUN_ON(worker_thread_);
+  
+  // Unregister from old transformer
+  if (packet_transformer_) {
+    packet_transformer_->UnsetNegotiationObserver();
+  }
+  
+  packet_transformer_ = std::move(packet_transformer);
+  
+  // Register with new transformer
+  if (packet_transformer_) {
+    packet_transformer_->SetNegotiationObserver(this);
+  }
+
+  if (media_channel_) {
+    media_channel_->SetPacketTransformer(signaled_ssrc_.value_or(0),
+                                         packet_transformer_);
+  }
+}
+
+void VideoRtpReceiver::OnSdpAttributeRequest(SdpFeature feature) {
+  RTC_DCHECK_RUN_ON(worker_thread_);
+  
+  // Trigger SDP renegotiation
+  if (on_negotiation_needed_) {
+    on_negotiation_needed_();
+  }
+}
+```
+
+### Sequence Diagram: Frame-Level Transformer with Negotiation
+
+```mermaid
+sequenceDiagram
+    participant User as Application/User Code
+    participant API as RtpReceiverInterface
+    participant Base as VideoRtpReceiver
+    participant Transformer as SFrameFrameTransformer
+    participant Delegate as RtpVideoStreamReceiverFrameTransformerDelegate
+
+    Note over User, Delegate: Frame-Level SFrame Transformer with Negotiation
+
+    User->>User: Create SFrame Frame Transformer
+    Note right of User: auto transformer =<br/>make_ref_counted<SFrameFrameTransformer>()
+
+    User->>Transformer: SetDecryptionKey(key)
+    
+    User->>API: SetDepacketizerToDecoderFrameTransformer(transformer)
+    API->>Base: SetDepacketizerToDecoderFrameTransformer(transformer)
+    
+    Base->>Transformer: SetNegotiationObserver(this)
+    Note over Base, Transformer: Register for SDP negotiations
+    
+    Transformer->>Base: OnSdpAttributeRequest(SdpFeature::kSFrame)
+    Note over Transformer, Base: Request SFrame SDP attribute
+    
+    Base->>Base: on_negotiation_needed_callback_()
+    Note over Base: Trigger SDP renegotiation
+    
+    Base->>Delegate: Create RtpVideoStreamReceiverFrameTransformerDelegate
+    Note over Base, Delegate: Delegate manages frame transformation
+
+    Note over User, Delegate: Initialization Complete with Negotiation
+```
+
+### Sequence Diagram: Packet-Level Transformer with Negotiation
+
+```mermaid
+sequenceDiagram
+    participant User as Application/User Code
+    participant API as RtpReceiverInterface
+    participant Base as VideoRtpReceiver
+    participant Transformer as SFramePacketTransformer
+    participant Delegate as RtpVideoStreamReceiverPacketTransformerDelegate
+
+    Note over User, Delegate: Packet-Level SFrame Transformer with Negotiation
+
+    User->>User: Create SFrame Packet Transformer
+    Note right of User: auto transformer =<br/>make_ref_counted<SFramePacketTransformer>()
+
+    User->>Transformer: SetDecryptionKey(key)
+    
+    User->>API: SetPacketTransformer(transformer)
+    API->>Base: SetPacketTransformer(transformer)
+    
+    Base->>Transformer: SetNegotiationObserver(this)
+    Note over Base, Transformer: Register for SDP negotiations
+    
+    Transformer->>Base: OnSdpAttributeRequest(SdpFeature::kSFrame)
+    Note over Transformer, Base: Request SFrame SDP attribute
+    
+    Base->>Base: on_negotiation_needed_callback_()
+    Note over Base: Trigger SDP renegotiation
+    
+    Base->>Delegate: Create RtpVideoStreamReceiverPacketTransformerDelegate
+    Note over Base, Delegate: Delegate manages packet transformation
+
+    Note over User, Delegate: Initialization Complete with Negotiation
+```
+
+## Design Rationale
+
+This design is primarily driven by how Chromium's `blink` level leverages the `Encoded Transform` API. The observer pattern allows:
+
+1. **Decoupling**: Transformers don't need direct access to SDP generation logic
+2. **Flexibility**: New SDP features can be added to the enum without changing transformer implementations
+3. **Automatic Triggering**: Negotiation is triggered immediately when transformers are attached
+4. **Clear Ownership**: RTP senders/receivers own the negotiation lifecycle
+
+## Alternative Approaches
+
+Other approaches to consider:
+
+1. **Direct SDP Modification**: Transformers directly modify MediaDescriptionOptions (see main implementation)
+2. **Configuration Object**: Pass configuration during transformer creation instead of runtime negotiation
+3. **Separate Negotiation API**: Decouple SDP feature requests from transformer lifecycle
+
+## Status
+
+This approach is documented for reference but is **not currently implemented** in the main codebase. The current implementation uses a different pattern where transformers directly modify SDP options during offer/answer creation.
+
+See the main architecture documentation for the currently implemented approach.

--- a/negotiation-trigger-proposals.md
+++ b/negotiation-trigger-proposals.md
@@ -99,17 +99,17 @@ class RtpSenderBase : public RtpSenderInternal {
     frame_transformer_ = std::move(frame_transformer);
     frame_transformer_features_ = features;
     
-    // Trigger negotiation if features changed
-    if (features_changed && on_negotiation_needed_) {
-      on_negotiation_needed_();
-    }
-    
     // Set transformer on worker thread
     if (media_channel_ && ssrc_ && !stopped_) {
       worker_thread_->BlockingCall([&] {
         media_channel_->SetEncoderToPacketizerFrameTransformer(
             ssrc_, frame_transformer_);
       });
+    }
+
+    // Trigger negotiation if features changed
+    if (features_changed && on_negotiation_needed_) {
+      on_negotiation_needed_();
     }
   }
 
@@ -145,72 +145,14 @@ class VideoRtpReceiver : public RtpReceiverInternal {
             signaled_ssrc_.value_or(0), frame_transformer_);
       }
     });
+
+    // On neegotiation needed trigger
   }
 
  private:
   std::vector<SdpFeature> frame_transformer_features_
       RTC_GUARDED_BY(signaling_thread_checker_);
 };
-```
-
-### Usage Example
-
-```cpp
-// Create SFrame transformer
-auto sframe_transformer = CreateSFrameTransformer();
-
-// Attach to sender with SFrame feature
-sender->SetPacketTransformer(sframe_transformer, {SdpFeature::kSFrame});
-
-// This triggers negotiation needed event, which causes:
-// 1. PeerConnection to call CreateOffer/CreateAnswer
-// 2. SDP generation to check transformer features
-// 3. Add "a=sframe" attribute to m-line if kSFrame feature present
-```
-
-### Advantages
-
-1. **Explicit Control**: Application has full visibility and control over which features are enabled
-2. **Simple Transformer Implementation**: Transformers don't need to know about negotiation
-3. **Testable**: Easy to test feature changes and negotiation triggers
-4. **Flexible**: Can attach transformers without features, or change features later
-5. **Thread-Safe**: Clear ownership - features stored on signaling thread, transformers on worker thread
-
-### Disadvantages
-
-1. **Application Responsibility**: Application must know which features to request
-2. **Timing**: Application must coordinate transformer attachment with feature specification
-3. **No Dynamic Discovery**: Transformers can't dynamically request features based on runtime state
-
-### Integration Points
-
-#### SDP Offer/Answer Generation
-
-When generating SDP, check sender/receiver features:
-
-```cpp
-// In MediaSessionDescriptionFactory
-for (auto& sender : transceivers->senders()) {
-  const auto& features = sender->GetTransformerFeatures();
-  
-  if (std::find(features.begin(), features.end(), 
-                SdpFeature::kSFrame) != features.end()) {
-    // Add a=sframe attribute to media description
-    media_desc->AddAttribute("sframe", "");
-  }
-}
-```
-
-#### Proxy Support
-
-Proxy classes updated to handle features parameter:
-
-```cpp
-// In rtp_sender_proxy.h
-PROXY_METHOD2(void,
-              SetFrameTransformer,
-              scoped_refptr<FrameTransformerInterface>,
-              const std::vector<SdpFeature>&)
 ```
 
 ## Proposal 2: FrameTransformerNegotiationObserver Pattern (Archived)
@@ -650,26 +592,3 @@ sequenceDiagram
 
     Note over User, Delegate: Initialization Complete with Negotiation
 ```
-
-## Design Rationale
-
-This design is primarily driven by how Chromium's `blink` level leverages the `Encoded Transform` API. The observer pattern allows:
-
-1. **Decoupling**: Transformers don't need direct access to SDP generation logic
-2. **Flexibility**: New SDP features can be added to the enum without changing transformer implementations
-3. **Automatic Triggering**: Negotiation is triggered immediately when transformers are attached
-4. **Clear Ownership**: RTP senders/receivers own the negotiation lifecycle
-
-## Alternative Approaches
-
-Other approaches to consider:
-
-1. **Direct SDP Modification**: Transformers directly modify MediaDescriptionOptions (see main implementation)
-2. **Configuration Object**: Pass configuration during transformer creation instead of runtime negotiation
-3. **Separate Negotiation API**: Decouple SDP feature requests from transformer lifecycle
-
-## Status
-
-This approach is documented for reference but is **not currently implemented** in the main codebase. The current implementation uses a different pattern where transformers directly modify SDP options during offer/answer creation.
-
-See the main architecture documentation for the currently implemented approach.

--- a/video-receiver.md
+++ b/video-receiver.md
@@ -2,418 +2,320 @@
 
 ## Overview
 
-This document describes how to integrate SFrame (Secure Frame) decryption into the WebRTC video receiver pipeline. The goal is to add secure end-to-end video reception capabilities while working with the existing RTP receiver infrastructure.
+This document describes how to integrate SFrame (Secure Frame) decryption into the WebRTC video receiver pipeline using both **frame-level** and **packet-level** transformation. The goal is to add secure end-to-end video reception capabilities while working with the existing RTP receiver infrastructure.
 
-SFrame decryption can work at two levels:
+**Coverage**:
+- **Frame-Level Transformation**: Decrypts complete video frames after depacketization using `SetDepacketizerToDecoderFrameTransformer()` with `SFrameFrameTransformer`
+- **Packet-Level Transformation**: Decrypts individual RTP packets before depacketization using `SetPacketTransformer()` with `SFramePacketTransformer`
 
-- **Per-frame**: Decrypts complete video frames after assembling them from RTP packets
-- **Per-packet**: Decrypts individual RTP packets before frame assembly
+Both approaches follow the same configuration and negotiation architecture but differ in transformation timing and granularity.Both approaches follow the same configuration and negotiation architecture but differ in transformation timing and granularity.
 
-## SFrame Transformer Initialization Flow
+## Frame-Level SFrame Transformer Initialization Flow
 
-The following diagram illustrates how SFrame transformer initialization flows from the API level down to the RtpVideoStreamReceiver2 component. This shows the "sunny day" scenario where all components are ready and the initialization completes successfully.
+The following diagram illustrates how SFrame frame transformers are configured in the WebRTC video receiver pipeline using `SetDepacketizerToDecoderFrameTransformer()`.
 
 ```mermaid
 sequenceDiagram
     participant User as Application/User Code
     participant API as RtpReceiverInterface
     participant Base as VideoRtpReceiver
-    participant Worker as Worker Thread
-    participant Channel as WebRtcVideoReceiveChannel
-    participant Stream as WebRtcVideoReceiveStream
-    participant Call as Call::CreateVideoReceiveStream
-    participant VSImpl as VideoReceiveStream2
-    participant RtpVideoReceiver as RtpVideoStreamReceiver2
+    participant Transformer as SFrameFrameTransformer
+    participant Delegate as RtpVideoStreamReceiverFrameTransformerDelegate
 
-    Note over User, RtpVideoReceiver: SFrame Transformer Initialization Flow
+    Note over User, Delegate: Frame-Level SFrame Transformer Initialization
 
-    %% API Level Initialization
-    User->>API: Call SetSFrameTransformer(transformer, options)
-    Note over User, API: 1. API Entry Point
-    Note right of User: User provides:<br/>- SFrameTransformerInterface<br/>- SFrameOptions (per-frame/per-packet mode)
+    %% Create SFrame Frame Transformer
+    User->>User: Create SFrame Frame Transformer
+    Note right of User: auto transformer =<br/>make_ref_counted<SFrameFrameTransformer>()
 
-    %% VideoRtpReceiver Processing
-    API->>Base: SetSFrameTransformer(transformer, options)
-    Note over API, Base: 2. Base Implementation
-    Base->>Base: Store sframe_transformer_ reference
+    User->>Transformer: SetDecryptionKey(key)
+    Note right of User: Configure decryption keys
 
-    %% Validation and Processing
-    Note over Base: 3. Validation Passed
-    Base->>Channel: SetSFrameTransformer(ssrc_, transformer, options)
-    Note over Base, Channel: 4. Media Channel Configuration
+    %% Set Frame Transformer
+    User->>API: SetDepacketizerToDecoderFrameTransformer(transformer)
+    Note over User, API: 1. Frame-Level API
+    
+    API->>Base: SetDepacketizerToDecoderFrameTransformer(transformer)
+    Note over API, Base: 2. VideoRtpReceiver stores transformer
+    
+    Base->>Delegate: Create RtpVideoStreamReceiverFrameTransformerDelegate
+    Note over Base, Delegate: 3. Delegate manages frame transformation
+    Note right of Delegate: Delegate will call transformer->Transform()<br/>for each assembled frame
 
-    %% Stream Lookup and Configuration
-    Channel->>Channel: find(ssrc) in receive_streams_
-    Note over Channel: 5. Stream Located Successfully
-    Channel->>Stream: SetSFrameTransformer(transformer, options)
-
-    %% Stream Configuration Update
-    Note over Channel, Stream: 6. Stream Configuration
-    Stream->>Stream: Update config_.sframe_stream_config.sframe_transformer
-    Stream->>Stream: Update config_.sframe_stream_config.sframe_options
-    Stream->>Stream: Set config_.sframe_stream_config.require_sframe = true
-    Note right of Stream: VideoReceiveStream::Config updated<br/>with SFrame settings
-
-    %% Stream Recreation and Creation Pipeline
-    Note over Stream: 7. Stream Recreation Required
-    Stream->>Stream: RecreateReceiveStream()
-    Note right of Stream: Stream recreation applies<br/>new SFrame configuration
-
-    %% Video Receive Stream Creation Pipeline
-    Stream->>Call: CreateVideoReceiveStream(config)
-    Note over Stream, Call: 8. Call Layer<br/>Creates VideoReceiveStream2
-
-    Call->>VSImpl: new VideoReceiveStream2(config)
-    Note over Call, VSImpl: 9. Video Receive Stream Implementation
-
-    VSImpl->>RtpVideoReceiver: Create RtpVideoStreamReceiver2
-    Note over VSImpl, RtpVideoReceiver: 10. RTP Video Stream Receiver Creation<br/>Handles incoming RTP packets
-
-    RtpVideoReceiver->>RtpVideoReceiver: Configure with SFrame settings from config
-    Note over RtpVideoReceiver: 11. Final Configuration
-    Note right of RtpVideoReceiver: RtpVideoStreamReceiver2 now configured<br/>with SFrame transformer<br/>Ready to decrypt frames/packets
-
-    %% Success Response
-    Note over User, RtpVideoReceiver: 12. Initialization Complete
+    Note over User, Delegate: 4. Initialization Complete<br/>Frames will be decrypted during reception
 ```
 
-### Key Flow Steps:
+1. **Transformer Creation**: User creates `SFrameFrameTransformer` for frame-level decryption
+2. **Key Configuration**: User configures decryption keys via `SetDecryptionKey()`
+3. **API Call**: User calls `SetDepacketizerToDecoderFrameTransformer()` to attach the transformer
+4. **Observer Registration**: `VideoRtpReceiver` registers itself as a negotiation observer with the transformer
+5. **SDP Negotiation**: Transformer immediately requests SFrame SDP attribute, triggering renegotiation
+6. **Delegate Creation**: `RtpVideoStreamReceiverFrameTransformerDelegate` is created to handle transformation callbacks
+7. **Decryption Active**: Assembled frames are now decrypted via the transformer after depacketization
 
-1. **API Entry Point**: User calls `SetSFrameTransformer()` with transformer and options
-2. **Base Implementation**: `VideoRtpReceiver` stores the transformer and validates readiness
-3. **Media Channel**: `WebRtcVideoReceiveChannel` locates the correct stream by SSRC
-4. **Stream Configuration**: `WebRtcVideoReceiveStream` updates configuration parameters in place
-5. **Stream Recreation**: Existing streams are recreated to apply new SFrame settings
-6. **Creation Pipeline**: Settings flow through Call → VideoReceiveStream2 → RtpVideoStreamReceiver2
-7. **Ready for Decryption**: RtpVideoStreamReceiver2 is now ready to decrypt frames/packets
+## Packet-Level SFrame Transformer Initialization Flow
 
-Once initialization is complete, the RtpVideoStreamReceiver2 component can perform decryption at two levels based on the configured `SFrameOptions`.
+The following diagram illustrates how SFrame packet transformers are configured in the WebRTC video receiver pipeline using `SetPacketTransformer()`.
 
-## C++ API Proposal
+```mermaid
+sequenceDiagram
+    participant User as Application/User Code
+    participant API as RtpReceiverInterface
+    participant Base as VideoRtpReceiver
+    participant Transformer as SFramePacketTransformer
+    participant Delegate as RtpVideoStreamReceiverPacketTransformerDelegate
 
-### Basic API Structure
+    Note over User, Delegate: Packet-Level SFrame Transformer Initialization
 
-The integration starts with extending `RtpReceiverInterface` to support SFrame transformers. This gives applications a clean way to inject decryption at the receiver level.
+    %% Create SFrame Packet Transformer
+    User->>User: Create SFrame Packet Transformer
+    Note right of User: auto transformer =<br/>make_ref_counted<SFramePacketTransformer>()
 
-```cpp
-class RtpReceiverInterface : public SFrameTransformerHost {
- public:
-  /**
-   * Sets up SFrame decryption for this RTP receiver.
-   * @param sframe_transformer The decryption implementation
-   * @param options Configuration for how SFrame should operate
-   */
-  virtual void SetSFrameTransformer(
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options) = 0;
+    User->>Transformer: SetDecryptionKey(key)
+    Note right of User: Configure decryption keys
 
-  virtual scoped_refptr<SFrameTransformerInterface> GetSFrameTransformer() = 0;
-};
+    %% Set Packet Transformer
+    User->>API: SetPacketTransformer(transformer)
+    Note over User, API: 1. Packet-Level API
+    
+    API->>Base: SetPacketTransformer(transformer)
+    Note over API, Base: 2. VideoRtpReceiver stores transformer
+    
+    Base->>Delegate: Create RtpVideoStreamReceiverPacketTransformerDelegate
+    Note over Base, Delegate: 3. Delegate manages packet transformation
+    Note right of Delegate: Delegate will call transformer->Transform()<br/>for each RTP packet
+
+    Note over User, Delegate: 4. Initialization Complete<br/>Packets will be decrypted during reception
 ```
+
+1. **Transformer Creation**: User creates `SFramePacketTransformer` for packet-level decryption
+2. **Key Configuration**: User configures decryption keys via `SetDecryptionKey()`
+3. **API Call**: User calls `SetPacketTransformer()` to attach the transformer
+4. **Observer Registration**: `VideoRtpReceiver` registers itself as a negotiation observer with the transformer
+5. **SDP Negotiation**: Transformer immediately requests SFrame SDP attribute, triggering renegotiation
+6. **Delegate Creation**: `RtpVideoStreamReceiverPacketTransformerDelegate` is created to handle transformation callbacks
+7. **Decryption Active**: RTP packets are now decrypted via the transformer before depacketization
 
 ## Implementation Architecture
 
 ### VideoRtpReceiver
 
-`VideoRtpReceiver` is the main implementation that inherits from `RtpReceiverInternal`. Here's how it handles SFrame configuration:
+`VideoRtpReceiver` implements the `RtpReceiverInternal` interface and the `FrameTransformerNegotiationObserver` interface to support both frame-level and packet-level transformers.
 
 ```cpp
-class VideoRtpReceiver: public RtpReceiverInternal {
+class VideoRtpReceiver : public RtpReceiverInternal {
  public:
-  /**
-   * Sets up the SFrame transformer and passes the configuration
-   * down to the media channel layer.
-   */
-  void SetSFrameTransformer(
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options) override;
+  void SetFrameTransformer(
+      scoped_refptr<FrameTransformerInterface> frame_transformer) override;
 
-  scoped_refptr<SFrameTransformerInterface> GetSFrameTransformer() override;
+  void SetPacketTransformer(
+      scoped_refptr<FrameTransformerInterface> packet_transformer) override;
 
  private:
-  // Keeps a reference to the configured SFrame transformer
-  scoped_refptr<SFrameTransformerInterface> sframe_transformer_;
+  // Stored transformer references
+  scoped_refptr<FrameTransformerInterface> frame_transformer_
+      RTC_GUARDED_BY(worker_thread_);
+  scoped_refptr<FrameTransformerInterface> packet_transformer_
+      RTC_GUARDED_BY(worker_thread_);
 };
 ```
 
-The implementation makes sure SFrame configuration is safely passed to the media channel:
+The implementation manages transformer lifecycle and propagates configuration to the media channel:
 
 ```cpp
-void VideoRtpReceiver::SetSFrameTransformer(
-    scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-    SFrameOptions options) {
-  sframe_transformer_ = sframe_transformer;
+void VideoRtpReceiver::SetFrameTransformer(
+    scoped_refptr<FrameTransformerInterface> frame_transformer) {
+  RTC_DCHECK_RUN_ON(worker_thread_);
+  
+  frame_transformer_ = std::move(frame_transformer);
 
-  // Pass configuration to media channel if everything is ready
-  if (media_channel_ && ssrc_) {
-    worker_thread_->BlockingCall([&] {
-      media_channel_->SetSFrameTransformer(ssrc_, sframe_transformer, options);
-    });
+  if (media_channel_) {
+    media_channel_->SetDepacketizerToDecoderFrameTransformer(
+        signaled_ssrc_.value_or(0), frame_transformer_);
   }
 }
 
-scoped_refptr<SFrameTransformerInterface> VideoRtpReceiver::GetSFrameTransformer()  {
-  return sframe_transformer_;
+void VideoRtpReceiver::SetPacketTransformer(
+    scoped_refptr<FrameTransformerInterface> packet_transformer) {
+  RTC_DCHECK_RUN_ON(worker_thread_);
+  
+  packet_transformer_ = std::move(packet_transformer);
+
+  if (media_channel_) {
+    media_channel_->SetPacketTransformer(signaled_ssrc_.value_or(0),
+                                         packet_transformer_);
+  }
 }
-```
-
-## SFrameStreamConfig
-
-The `SFrameStreamConfig` structure consolidates all SFrame-related configuration parameters for media streams. This configuration structure is utilized by both media senders and receivers, with each maintaining its own instance to ensure proper encapsulation of SFrame settings.
-
-The structure contains three primary components: `SFrameOptions` and `SFrameTransformerInterface` are populated through the `SetSFrameTransformer` API call, while the `require_sframe` property is configured separately during SDP negotiation. This separation is necessary to accommodate scenarios where SFrame may be enabled through sender-side configuration without necessarily having a transformer available on the receiver side.
-
-```cpp
-struct SFrameStreamConfig {
-  // SDP negotiated if we should require SFrame
-  bool require_sframe;
-
-  // Options provided with `SetSFrameTransformer`
-  // Should it be optional ? Or simply keep defaults?
-  SFrameOptions options;
-
-  // Transformer
-  scoped_refptr<SFrameTransformerInterface> sframe_transformer;
-};
 ```
 
 ## Media Channel Layer
 
-### Extending VideoMediaReceiveChannelInterface
+### WebRtcVideoReceiveChannel
 
-To support SFrame at the media channel level, we need to extend the interface with a new method:
+The `WebRtcVideoReceiveChannel` class implements the video receive channel interface and manages multiple video receive streams. It provides methods to configure transformers on a per-SSRC basis.
 
 ```cpp
-class VideoMediaReceiveChannelInterface {
+class WebRtcVideoReceiveChannel : public MediaChannelUtil,
+                                  public VideoMediaReceiveChannelInterface {
  public:
-  /**
-   * Configures SFrame decryption for a specific stream.
-   * @param ssrc The stream identifier
-   * @param sframe_transformer The decryption implementation
-   * @param options How SFrame should operate (per-frame vs per-packet)
-   */
-  virtual void SetSFrameTransformer(
+  void SetDepacketizerToDecoderFrameTransformer(
       uint32_t ssrc,
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options) = 0;
+      scoped_refptr<FrameTransformerInterface> frame_transformer) override;
+
+  void SetPacketTransformer(
+      uint32_t ssrc,
+      scoped_refptr<FrameTransformerInterface> packet_transformer) override;
+
+ private:
+  std::map<uint32_t, WebRtcVideoReceiveStream*> receive_streams_;
+  scoped_refptr<FrameTransformerInterface> unsignaled_frame_transformer_
+      RTC_GUARDED_BY(thread_checker_);
+  scoped_refptr<FrameTransformerInterface> unsignaled_packet_transformer_
+      RTC_GUARDED_BY(thread_checker_);
 };
 ```
 
-### WebRtcVideoReceiveChannel Implementation
-
-This is where SFrame configuration gets applied to actual video streams:
+The implementation looks up the correct stream and delegates the transformer configuration:
 
 ```cpp
-class WebRtcVideoReceiveChannel : public VideoMediaReceiveChannelInterface {
- public:
-  /**
-   * Finds the right video stream and applies SFrame configuration to it.
-   */
-  void SetSFrameTransformer(
-      uint32_t ssrc,
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options) override;
-};
-```
-
-The implementation looks up the correct stream and handles errors gracefully:
-
-```cpp
-void WebRtcVideoReceiveChannel::SetSFrameTransformer(
+void WebRtcVideoReceiveChannel::SetDepacketizerToDecoderFrameTransformer(
     uint32_t ssrc,
-    scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-    SFrameOptions options) {
+    scoped_refptr<FrameTransformerInterface> frame_transformer) {
   RTC_DCHECK_RUN_ON(&thread_checker_);
+  
+  if (ssrc == 0) {
+    // Unsignaled stream - store transformer for later
+    unsignaled_frame_transformer_ = std::move(frame_transformer);
+    return;
+  }
 
   auto matching_stream = receive_streams_.find(ssrc);
   if (matching_stream != receive_streams_.end()) {
-    matching_stream->second->SetSFrameTransformer(sframe_transformer, options);
+    matching_stream->second->SetDepacketizerToDecoderFrameTransformer(
+        std::move(frame_transformer));
+  }
+}
+
+void WebRtcVideoReceiveChannel::SetPacketTransformer(
+    uint32_t ssrc,
+    scoped_refptr<FrameTransformerInterface> packet_transformer) {
+  RTC_DCHECK_RUN_ON(&thread_checker_);
+  
+  if (ssrc == 0) {
+    // Unsignaled stream - store transformer for later
+    unsignaled_packet_transformer_ = std::move(packet_transformer);
+    return;
+  }
+
+  auto matching_stream = receive_streams_.find(ssrc);
+  if (matching_stream != receive_streams_.end()) {
+    matching_stream->second->SetPacketTransformer(packet_transformer);
   } else {
-    RTC_LOG(LS_ERROR) << "Could not find receive stream with SSRC " << ssrc
-                      << " to configure SFrame decryption";
+    RTC_LOG(LS_ERROR) << "No stream found to attach packet transformer";
   }
 }
 ```
 
-### Individual Stream Configuration
+### WebRtcVideoReceiveStream
 
-Each video stream is represented by a `WebRtcVideoReceiveStream` object. When SFrame configuration is applied, the stream must be recreated to properly integrate the new decryption settings. The configuration parameters are stored within the `SFrameStreamConfig` structure, which is embedded in the stream's configuration hierarchy for centralized management.
-
-```cpp
-struct VideoReceiveStreamParameters {
-  /* Other fields */
-  VideoReceiveStreamInterface::Config config;
-};
-
-struct VideoReceiveStreamInterface::Config {
-  /* Other fields */
-  SFrameStreamConfig sframe_stream_config;
-};
-```
+Each video stream is represented by a `WebRtcVideoReceiveStream` object which wraps the internal `VideoReceiveStream2`. Transformer configuration is stored in `VideoReceiveStreamInterface::Config` and triggers stream recreation.
 
 ```cpp
 class WebRtcVideoReceiveStream {
  public:
-  /**
-   * Applies SFrame configuration to this video stream.
-   * This triggers recreation of the underlying WebRTC stream.
-   */
-  void SetSFrameTransformer(
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options);
+  void SetDepacketizerToDecoderFrameTransformer(
+      scoped_refptr<FrameTransformerInterface> frame_transformer);
 
-  // Holds configuration of the stream
+  void SetPacketTransformer(
+      scoped_refptr<FrameTransformerInterface> packet_transformer);
+
+ private:
+  void RecreateReceiveStream();
+  
   VideoReceiveStreamInterface::Config config_;
+  VideoReceiveStreamInterface* stream_;
 };
 ```
 
-Here's how stream recreation works:
+When a frame transformer is set, the stream configuration is updated and propagated to the stream:
 
 ```cpp
-void WebRtcVideoReceiveChannel::WebRtcVideoReceiveStream::SetSFrameTransformer(
-    scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-    SFrameOptions options) {
-  RTC_DCHECK_RUN_ON(&thread_checker_);
-
-  // Update the stream configuration
-  config_.sframe_stream_config.sframe_transformer = sframe_transformer;
-  config_.sframe_stream_config.sframe_options = options;
-  // NOTE: require_sframe is not automatically set - this is a current gap
-
-  // Recreate the stream with new SFrame settings
-  if (stream_) {
-    RTC_LOG(LS_INFO)
-        << "Setting SFrameTransformer (recv) because of SetSFrameTransformer, "
-           "remote_ssrc="
-        << config_.rtp.remote_ssrc;
-    stream_->SetSFrameTransformer(sframe_transformer, options);
-  }
+void WebRtcVideoReceiveChannel::WebRtcVideoReceiveStream::
+    SetDepacketizerToDecoderFrameTransformer(
+        scoped_refptr<FrameTransformerInterface> frame_transformer) {
+  config_.frame_transformer = frame_transformer;
+  if (stream_)
+    stream_->SetDepacketizerToDecoderFrameTransformer(frame_transformer);
 }
 ```
 
-### MediaReceiveStreamInterface
-
-Extend `MediaReceiveStreamInterface` with new method which will allow passing by provided `SFrameTransformer`.
+When a packet transformer is set, the stream configuration is updated and the stream is recreated:
 
 ```cpp
-class MediaReceiveStreamInterface : public ReceiveStreamInterface {
- public:
-
-  virtual void SetSFrameTransformer(
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options) = 0;
-};
+void WebRtcVideoReceiveChannel::WebRtcVideoReceiveStream::SetPacketTransformer(
+    scoped_refptr<FrameTransformerInterface> packet_transformer) {
+  config_.packet_transformer = packet_transformer;
+  RecreateReceiveStream();
+}
 ```
 
-It will be inherited by `VideoReceiveStreamInterface`.
+### VideoReceiveStreamInterface::Config
+
+Both frame and packet transformers are stored directly in the `VideoReceiveStreamInterface::Config` structure:
+
+```cpp
+struct VideoReceiveStreamInterface::Config {  
+  // Optional frame transformer (depacketizer to decoder transformation)
+  scoped_refptr<FrameTransformerInterface> frame_transformer;
+
+  // Optional packet transformer (per-packet transformation)
+  scoped_refptr<FrameTransformerInterface> packet_transformer;
+
+  // ... other fields
+};
+```
 
 ### VideoReceiveStream2
 
-`VideoReceiveStream2` inherits from `MediaReceiveStreamInterface` and implements `SetSFrameTransformer` method to pass created `SFrameTransformer` into `RtpVideoStreamReceiver2` object which performs actual media actions.
+The `VideoReceiveStream2` is created by the `Call` interface and manages the video decoding and receiving pipeline. It creates the `RtpVideoStreamReceiver2` with transformers from the configuration.
 
 ```cpp
-void VideoReceiveStream2::SetSFrameTransformer(
-    scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-    SFrameOptions sframe_options) {
-  rtp_video_stream_receiver_.SetSFrameTransformer(std::move(sframe_transformer),
-                                                  sframe_options);
-}
+class VideoReceiveStream2 : public VideoReceiveStreamInterface,
+                            public VideoStreamBufferControllerInterface {
+ public:
+  VideoReceiveStream2(
+      const Environment& env,
+      Call* call,
+      int num_cpu_cores,
+      PacketRouter* packet_router,
+      VideoReceiveStreamInterface::Config config,
+      CallStats* call_stats,
+      clock::Clock* clock,
+      VCMTiming* timing,
+      NackPeriodicProcessor* nack_periodic_processor,
+      DecodeSynchronizer* decode_sync);
+
+  void SetDepacketizerToDecoderFrameTransformer(
+      scoped_refptr<FrameTransformerInterface> frame_transformer) override;
+
+  void SetPacketTransformer(
+      scoped_refptr<FrameTransformerInterface> packet_transformer);
+};
 ```
 
 ### RtpVideoStreamReceiver2
 
-```cpp
-void RtpVideoStreamReceiver2::SetSFrameTransformer(
-    scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-    SFrameOptions sframe_options) {
-  RTC_DCHECK_RUN_ON(&packet_sequence_checker_);
-  if (sframe_transformer) {
-    sframe_decryptor_ = std::make_unique<VideoSFrameDecryptor>(
-        std::move(sframe_transformer), sframe_options);
-  } else {
-    sframe_decryptor_.reset();
-  }
-}
-```
-
-## RTP Video Stream Receiver - Where Decryption Happens
-
-### VideoSFrameDecryptor
-
-The `VideoSFrameDecryptor` class provides a clean abstraction layer that encapsulates all SFrame-related decryption operations for video streams. This design promotes better code organization and maintainability by consolidating decryption logic within a dedicated component.
+The `RtpVideoStreamReceiver2` is created with both frame and packet transformers and manages RTP packet reception, depacketization, and frame assembly.
 
 ```cpp
-class VideoSFrameDecryptor {
- public:
-  enum class DecryptionResult {
-    kSuccess,
-    kFailure,
-    kDrop,
-    kSkip,
-  };
-
-  VideoSFrameDecryptor(scoped_refptr<SFrameTransformerInterface> sframe_transformer, SFrameOptions options_);
-
-  ~VideoSFrameDecryptor();
-
-  DecryptionResult MaybeDecryptFrame(CopyOnWriteBuffer& payload);
-
-  DecryptionResult MaybeDecryptPacket(CopyOnWriteBuffer& payload);
-
- private:
-  scoped_refptr<SFrameTransformerInterface> sframe_transformer_;
-
-  SFrameOptions options_;
-};
-```
-
-The implementation handles all operations required to perform SFrame decryption, providing a standardized interface for both per-frame and per-packet decryption modes.
-
-Example code:
-```cpp
-VideoSFrameDecryptor::DecryptionResult VideoSFrameDecryptor::MaybeDecryptFrame(
-    CopyOnWriteBuffer& payload) {
-  if (sframe_options_.mode == SFrameMode::kPerPacket) {
-    return DecryptionResult::kSkip;
-  }
-
-  if (!sframe_transformer_) {
-    return DecryptionResult::kDrop;
-  }
-
-  sframe_transformer_->Transform(payload);
-
-  return DecryptionResult::kSuccess;
-}
-```
-
-**Summary**: Manages per-frame SFrame decryption by validating the decryption mode, verifying transformer availability, applying SFrame decryption to the complete frame payload in-place.
-
-```cpp
-VideoSFrameDecryptor::DecryptionResult
-VideoSFrameDecryptor::MaybeDecryptPacket(CopyOnWriteBuffer& payload) {
-  if (sframe_options_.mode == SFrameMode::kPerFrame) {
-    return DecryptionResult::kSkip;
-  }
-
-  if (!sframe_transformer_) {
-    return DecryptionResult::kDrop;
-  }
-
-  sframe_transformer_->Transform(payload);
-
-  return DecryptionResult::kSuccess;
-}
-```
-
-**Summary**: Manages per-packet SFrame decryption by validating the decryption mode, verifying transformer availability, applying SFrame decryption to the packet payload directly, and modifying the payload in-place with decrypted data.
-
-### RtpVideoStreamReceiver2 Configuration
-
-The `RtpVideoStreamReceiver2` is configured during construction based on the SFrame settings in the `VideoReceiveStreamInterface::Config` or with `SetSFrameTransformer` as shown above.
-
-```cpp
-class RtpVideoStreamReceiver2 : public RtpPacketSinkInterface {
+class RtpVideoStreamReceiver2 : public LossNotificationSender,
+                                public RecoveredPacketReceiver,
+                                public RtpPacketSinkInterface,
+                                public KeyFrameRequestSender,
+                                public NackSender,
+                                public OnDecryptedFrameCallback,
+                                public OnDecryptionStatusChangeCallback,
+                                public RtpVideoFrameReceiver {
  public:
   RtpVideoStreamReceiver2(
       const Environment& env,
@@ -422,194 +324,227 @@ class RtpVideoStreamReceiver2 : public RtpPacketSinkInterface {
       RtcpRttStats* rtt_stats,
       PacketRouter* packet_router,
       const VideoReceiveStreamInterface::Config* config,
-      /* ... other parameters ... */);
+      ReceiveStatistics* rtp_receive_statistics,
+      RtcpPacketTypeCounterObserver* rtcp_packet_type_counter_observer,
+      RtcpCnameCallback* rtcp_cname_callback,
+      NackPeriodicProcessor* nack_periodic_processor,
+      OnCompleteFrameCallback* complete_frame_callback,
+      scoped_refptr<FrameDecryptorInterface> frame_decryptor,
+      scoped_refptr<FrameTransformerInterface> frame_transformer,
+      scoped_refptr<FrameTransformerInterface> packet_transformer);
+  
+  void SetDepacketizerToDecoderFrameTransformer(
+      scoped_refptr<FrameTransformerInterface> frame_transformer);
+
+  void SetPacketTransformer(
+      scoped_refptr<FrameTransformerInterface> packet_transformer);
 
  private:
-  std::unique_ptr<VideoSFrameDecryptor> sframe_decryptor_;
+  scoped_refptr<RtpVideoStreamReceiverFrameTransformerDelegate>
+      frame_transformer_delegate_;
+  scoped_refptr<RtpVideoStreamReceiverPacketTransformerDelegate>
+      packet_transformer_delegate_;
 };
 ```
 
-### RtpVideoStreamReceiver2 Construction
+The constructor creates transformer delegates with the configuration, passing transformers to manage the decryption workflow.
 
-The `RtpVideoStreamReceiver2` constructor conditionally instantiates the `VideoSFrameDecryptor` based on the SFrame requirement configuration, ensuring optimal resource utilization.
+## RtpVideoStreamReceiver2 Configuration
+
+### Frame Transformer Delegate
+
+When a frame transformer is configured, `RtpVideoStreamReceiver2` creates an `RtpVideoStreamReceiverFrameTransformerDelegate` to handle the transformation workflow:
 
 ```cpp
-RtpVideoStreamReceiver2::RtpVideoStreamReceiver2(
-    const VideoReceiveStreamInterface::Config* config)
-    : /* ... other initializations ... */ {
-  
-  // Initialize SFrame decryptor if require_frame_encryption is enabled and
-  // SFrame transformer is provided in config
-  if (config->sframe_stream_config.require_sframe) {
-    sframe_decryptor_ = std::make_unique<VideoSFrameDecryptor>(
-        config->sframe_stream_config.sframe_transformer,
-        config->sframe_stream_config.sframe_options);
-  }
-}
+class RtpVideoStreamReceiverFrameTransformerDelegate 
+    : public TransformedFrameCallback {
+ public:
+  RtpVideoStreamReceiverFrameTransformerDelegate(
+      RtpVideoFrameReceiver* receiver,
+      Clock* clock,
+      scoped_refptr<FrameTransformerInterface> frame_transformer,
+      Thread* network_thread,
+      uint32_t ssrc);
+
+  void Init();
+
+  // Transforms assembled frames before decoding
+  void TransformFrame(std::unique_ptr<RtpFrameObject> frame);
+
+  // Callback when transformation completes
+  void OnTransformedFrame(
+      std::unique_ptr<TransformableFrameInterface> frame) override;
+
+  // Delivers transformed frame back to receiver
+  void ManageFrame(std::unique_ptr<RtpFrameObject> frame);
+};
 ```
 
-### SFrame Transformation Flow in RtpVideoStreamReceiver2
+The delegate workflow:
+1. **TransformFrame**: Receives assembled frames from the receiver, wraps them in `TransformableFrameInterface`, and passes to the transformer
+2. **Transform**: The `SFrameFrameTransformer` decrypts the frame data
+3. **OnTransformedFrame**: Receives decrypted frame from transformer
+4. **ManageFrame**: Delivers decrypted frame back to `RtpVideoStreamReceiver2` for decoding
 
-The following diagram shows how received RTP packets and assembled frames flow through RtpVideoStreamReceiver2 and where SFrame decryption is applied:
+### Packet Transformer Delegate
+
+When a packet transformer is configured, `RtpVideoStreamReceiver2` creates an `RtpVideoStreamReceiverPacketTransformerDelegate` to handle packet-level transformation. This operates **before** depacketization, transforming individual RTP packets.
+
+```cpp
+class RtpVideoStreamReceiverPacketTransformerDelegate 
+    : public TransformedFrameCallback {
+ public:
+  RtpVideoStreamReceiverPacketTransformerDelegate(
+      Clock* clock,
+      scoped_refptr<FrameTransformerInterface> packet_transformer,
+      Thread* network_thread,
+      uint32_t ssrc);
+
+  void Init();
+  void Reset();
+
+  // Callback when transformation completes
+  void OnTransformedFrame(
+      std::unique_ptr<TransformableFrameInterface> packet) override;
+
+  void StartShortCircuiting() override;
+
+ private:
+  scoped_refptr<FrameTransformerInterface> packet_transformer_
+      RTC_GUARDED_BY(network_sequence_checker_);
+  TaskQueueBase* const network_thread_;
+  const uint32_t ssrc_;
+  Clock* const clock_;
+  bool short_circuit_ RTC_GUARDED_BY(network_sequence_checker_) = false;
+};
+```
+
+The packet delegate workflow:
+1. **Packet Reception**: Receives RTP packets before depacketization, wraps each packet in `TransformableFrameInterface`
+2. **Transform**: The `SFramePacketTransformer` decrypts each packet's payload individually
+3. **OnTransformedFrame**: Receives decrypted packets from transformer
+4. **Packet Delivery**: Delivers transformed packets back to the receiver pipeline for depacketization
+
+### Transformation Flow in RtpVideoStreamReceiver2
+
+The following diagram shows how received RTP packets flow through RtpVideoStreamReceiver2 with both packet-level and frame-level transformation paths:
 
 ```mermaid
 flowchart TD
-    A[Received RTP Packet] --> B[OnReceivedPayloadData]
+    A[Received RTP Packet] --> B[RtpVideoStreamReceiver2::OnRtpPacket]
     
-    B --> C[VideoSFrameDecryptor::<br/>MaybeDecryptPacket]
+    B --> C{packet_transformer_<br/>delegate_?}
     
-    C --> C1{Decryption Result}
+    C -->|Yes - Packet Level| D[RtpVideoStreamReceiverPacketTransformerDelegate::<br/>Transform Packet]
+    C -->|No| E[RtpVideoStreamReceiver2::ReceivePacket<br/>Direct Path]
     
-    C1 -->|kSuccess| D[Packet Decrypted<br/>Continue Processing]
-    C1 -->|kSkip| E[No Packet Decryption<br/>Per-Frame Mode]
-    C1 -->|kDrop/kFailure| Z[Drop Packet<br/>Return]
+    D --> F[SFramePacketTransformer::<br/>Decrypt Packet]
     
-    D --> F[Depacketization]
-    E --> F
+    F --> G[Packet Decrypted]
     
-    F --> G[Frame Assembly]
+    G --> H[RtpVideoStreamReceiverPacketTransformerDelegate::<br/>OnTransformedFrame]
     
-    G --> H[StartNextDecode]
+    H --> I[Pass to Depacketizer]
     
-    H --> I[VideoSFrameDecryptor::<br/>MaybeDecryptFrame]
+    I --> J[Depacketization]
+    E --> J
     
-    I --> I1{Decryption Result}
+    J --> K[VideoRtpDepacketizer::<br/>Based on Codec Type]
     
-    I1 -->|kSuccess| J[Frame Decrypted<br/>Headers Updated]
-    I1 -->|kSkip| K[No Frame Decryption<br/>Per-Packet Mode]
-    I1 -->|kDrop/kFailure| Z1[Drop Frame<br/>Return]
+    K --> L[Assemble Frame from Packets]
     
-    J --> L[Pass to Decoder]
-    K --> L
+    L --> M[RtpVideoStreamReceiver2::OnAssembledFrame]
     
-    L --> M[Decrypted Video Data<br/>Ready for Rendering]
+    M --> N{frame_transformer_<br/>delegate_?}
     
-    style C fill:#e1f5fe
-    style D fill:#fff3e0
-    style I fill:#e1f5fe
-    style J fill:#fff3e0
-    style M fill:#c8e6c9
-    style Z fill:#ffcdd2
-    style Z1 fill:#ffcdd2
+    N -->|Yes - Frame Level| O[RtpVideoStreamReceiverFrameTransformerDelegate::<br/>TransformFrame]
+    N -->|No| P[RtpVideoStreamReceiver2::OnCompleteFrames]
+    
+    O --> Q[SFrameFrameTransformer::<br/>Decrypt Entire Frame]
+    
+    Q --> R[Frame Decrypted]
+    
+    R --> S[RtpVideoStreamReceiverFrameTransformerDelegate::<br/>OnTransformedFrame]
+    
+    S --> T[RtpVideoStreamReceiverFrameTransformerDelegate::<br/>ManageFrame]
+    
+    T --> U[RtpVideoStreamReceiver2::OnCompleteFrames]
+    P --> U
+    
+    U --> V[Decrypted Video Data<br/>Ready for Decoding]
+    
+    style D fill:#e1f5fe
+    style F fill:#fff3e0
+    style H fill:#e1f5fe
+    style O fill:#c8e6c9
+    style Q fill:#a5d6a7
+    style S fill:#c8e6c9
+    style V fill:#ffeb3b
 ```
 
-### RtpVideoStreamReceiver2 Overview
+**Flow Explanation**:
 
-The `RtpVideoStreamReceiver2` class is where the actual video processing happens. It receives RTP packets and assembles them into complete frames.
+1. **Packet Reception**: `OnRtpPacket` receives RTP packet from network
+2. **Packet-Level Path** (if configured):
+   - Packet transformer delegate intercepts the RTP packet
+   - Each packet is decrypted before depacketization
+   - Decrypted packet continues to depacketization
+3. **Depacketization**: RTP packets (possibly decrypted) are depacketized into encoded frames
+4. **Frame Assembly**: Multiple packets are assembled into complete frames
+5. **Frame-Level Path** (if configured):
+   - Frame transformer delegate intercepts the assembled frame
+   - Entire frame is decrypted after depacketization
+   - Decrypted frame is passed to the decoder
+6. **Decoding**: Final frames are sent to the video decoder
 
-### Processing Received Packets
+### RtpVideoStreamReceiver2 Processing Flow
 
-When `RtpVideoStreamReceiver2` receives an RTP packet, it can apply SFrame decryption at the appropriate point in the pipeline:
+When `RtpVideoStreamReceiver2` receives an RTP packet, it checks if a packet transformer delegate exists and routes accordingly:
 
 ```cpp
-void RtpVideoStreamReceiver2::OnReceivedPayloadData(
-    ArrayView<const uint8_t> payload,
-    const RtpPacketReceived& rtp_packet,
-    const RTPVideoHeader& video) {
-  
-  // Apply per-packet SFrame decryption before depacketization
-  if (sframe_decryptor_) {
-    CopyOnWriteBuffer payload_buffer = rtp_packet.PayloadBuffer();
-    
-    switch (sframe_decryptor_->MaybeDecryptPacket(payload_buffer)) {
-      case VideoSFrameDecryptor::DecryptionResult::kDrop:
-        // Drop packet if decryption fails or transformer not available
-        return;
-      case VideoSFrameDecryptor::DecryptionResult::kSuccess:
-        // Packet decrypted successfully
-        break;
-      case VideoSFrameDecryptor::DecryptionResult::kFailure:
-        // Decryption failed, drop packet
-        return;
-      case VideoSFrameDecryptor::DecryptionResult::kSkip:
-        // Per-frame mode configured, continue with normal processing
-        break;
-    }
+void RtpVideoStreamReceiver2::OnRtpPacket(const RtpPacketReceived& packet) {
+  RTC_DCHECK_RUN_ON(&packet_sequence_checker_);
+
+  if (!receiving_)
+    return;
+
+  // If there's a packet transformer delegate, packets are transformed
+  // before entering the normal receive pipeline
+  // (Implementation would transform packet here)
+
+  ReceivePacket(packet);
+
+  // Update receive statistics after ReceivePacket
+  if (!packet.recovered()) {
+    rtp_receive_statistics_->OnRtpPacket(packet);
   }
 
-  // Continue with standard depacketization and frame assembly
-  // ...
+  if (packet_sink_) {
+    packet_sink_->OnRtpPacket(packet);
+  }
 }
 ```
 
-### SFrame Decryption Integration in Frame Processing
-
-SFrame frame-level decryption is performed in the `StartNextDecode()` method after frame assembly. This happens before the frame is passed to the reference finder or decoder pipeline:
+The `OnAssembledFrame` method handles frame-level transformation after depacketization:
 
 ```cpp
-void RtpVideoStreamReceiver2::StartNextDecode() {
-  // ... frame selection logic ...
-  
-  // Attempt SFrame frame-level decryption if decryptor is available
-  if (sframe_decryptor_) {
-    auto decryption_result = sframe_decryptor_->MaybeDecryptFrame(frame->GetEncodedData());
-    switch (decryption_result) {
-      case VideoSFrameDecryptor::DecryptionResult::kDrop:
-        // Drop frame if decryption fails
-        return;
-      case VideoSFrameDecryptor::DecryptionResult::kFailure:
-        // Continue processing even if decryption failed
-        return;
-      case VideoSFrameDecryptor::DecryptionResult::kSuccess:
-        // Frame has been decrypted, update frame data
-        break;
-      case VideoSFrameDecryptor::DecryptionResult::kSkip:
-        // SFrame decryption not applicable, continue with normal processing
-        break;
-    }
-  }
+void RtpVideoStreamReceiver2::OnAssembledFrame(
+    std::unique_ptr<RtpFrameObject> frame) {
+  RTC_DCHECK_RUN_ON(&packet_sequence_checker_);
+  RTC_DCHECK(frame);
 
-  // Pass to frame transformer or reference finder
+  // Handle loss notification and keyframe requests
+  // ...
+
+  // Route to appropriate transformation path
   if (buffered_frame_decryptor_ != nullptr) {
     buffered_frame_decryptor_->ManageEncryptedFrame(std::move(frame));
   } else if (frame_transformer_delegate_) {
+    // Frame-level transformation: decrypt complete frame
     frame_transformer_delegate_->TransformFrame(std::move(frame));
   } else {
-    // Frame continues to reference finder and eventually to decoder
-    reference_finder_->ManageFrame(std::move(frame));
+    // No transformation: pass directly to reference finder
+    OnCompleteFrames(reference_finder_->ManageFrame(std::move(frame)));
   }
 }
-```
-
-The method processes the decrypted frame through the normal WebRTC pipeline, either through frame transformers or directly to the reference finder for eventual delivery to the decoder.
-
-## SFrame Depacketizer
-
-SFrame decryption requires specialized depacketization to handle the encrypted payload format. The `VideoRtpDepacketizerSFrame` class provides this functionality by extending the standard RTP depacketization interface.
-
-```cpp
-class VideoRtpDepacketizerSFrame : public VideoRtpDepacketizer {
- public:
-  ~VideoRtpDepacketizerSFrame() override = default;
-
-  std::optional<ParsedRtpPayload> Parse(CopyOnWriteBuffer rtp_payload) override;
-
- private:
-  // SFrame RTP header size is always 1 byte
-  static constexpr size_t kSFrameRtpHeaderSize = 1;
-};
-```
-
-The depacketizer handles SFrame-specific RTP payload format, extracting the SFrame ciphertext from the RTP payload and preparing it for decryption. The depacketizer processes the SFrame RTP header to determine packet boundaries and reassembly information.
-
-```
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|V=2|P|X|  CC   |M|     PT      |       sequence number         |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           timestamp                           |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|           synchronization source (SSRC) identifier            |
-+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
-|            contributing source (CSRC) identifiers             |
-|                             ....                              |
-+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
-|S E x x x x x x|                                               |
-|                                                               |
-:                       SFrame payload                          :
-|                                                               |
-|                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                               :    OPTIONAL RTP padding       |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ```

--- a/video-sender.md
+++ b/video-sender.md
@@ -2,507 +2,546 @@
 
 ## Overview
 
-This document describes how to integrate SFrame (Secure Frame) encryption into the WebRTC video sender pipeline. The goal is to add secure end-to-end video transmission capabilities while working with the existing RTP sender infrastructure.
+This document describes how to integrate SFrame (Secure Frame) encryption into the WebRTC video sender pipeline using both **frame-level** and **packet-level** transformation. The goal is to add secure end-to-end video transmission capabilities while working with the existing RTP sender infrastructure.
 
-SFrame encryption can work at two levels:
+**Coverage**:
+- **Frame-Level Transformation**: Encrypts complete encoded frames before packetization using `SetFrameTransformer()` with `SFrameFrameTransformer`
+- **Packet-Level Transformation**: Encrypts individual RTP packets after packetization using `SetPacketTransformer()` with `SFramePacketTransformer`
 
-- **Per-frame**: Encrypts complete video frames before they're split into RTP packets
-- **Per-packet**: Encrypts individual RTP packets after packetization
+Both approaches follow the same configuration and negotiation architecture but differ in transformation timing and granularity.
 
-## SFrame Transformer Initialization Flow
+## Frame-Level SFrame Transformer Initialization Flow
 
-The following diagram illustrates how SFrame transformer initialization flows from the API level down to the RTPSenderVideo component. This shows the "sunny day" scenario where all components are ready and the initialization completes successfully.
+The following diagram illustrates how SFrame frame transformers are configured in the WebRTC video sender pipeline using `SetFrameTransformer()`.
 
 ```mermaid
 sequenceDiagram
     participant User as Application/User Code
     participant API as RtpSenderInterface
     participant Base as RtpSenderBase
-    participant Worker as Worker Thread
-    participant Channel as WebRtcVideoSendChannel
-    participant Stream as WebRtcVideoSendStream
-    participant Call as Call::CreateVideoSendStream
-    participant VSImpl as VideoSendStreamImpl
-    participant RtpVideoSender as RtpVideoSender
-    participant RTPSender as RTPSenderVideo
+    participant Transformer as SFrameFrameTransformer
+    participant Delegate as RtpSenderVideoFrameTransformerDelegate
 
-    Note over User, RTPSender: SFrame Transformer Initialization Flow
+    Note over User, Delegate: Frame-Level SFrame Transformer Initialization
 
-    %% API Level Initialization
-    User->>API: Call SetSFrameTransformer(transformer, options)
-    Note over User, API: 1. API Entry Point
-    Note right of User: User provides:<br/>- SFrameTransformerInterface<br/>- SFrameOptions (per-frame/per-packet mode)
+    %% Create SFrame Frame Transformer
+    User->>User: Create SFrame Frame Transformer
+    Note right of User: auto transformer =<br/>make_ref_counted<SFrameFrameTransformer>()
 
-    %% RtpSenderBase Processing
-    API->>Base: SetSFrameTransformer(transformer, options)
-    Note over API, Base: 2. Base Implementation
-    Base->>Base: Store sframe_transformer_ reference
+    User->>Transformer: SetEncryptionKey(key)
+    Note right of User: Configure encryption keys
 
-    %% Validation and Processing
-    Note over Base: 3. Validation Passed
-    Base->>Channel: SetSFrameTransformer(ssrc_, transformer, options)
-    Note over Base, Channel: 4. Media Channel Configuration
+    %% Set Frame Transformer
+    User->>API: SetFrameTransformer(transformer)
+    Note over User, API: 1. Frame-Level API
+    
+    API->>Base: SetFrameTransformer(transformer)
+    Note over API, Base: 2. RtpSenderBase stores transformer
+    
+    Base->>Delegate: Create RtpSenderVideoFrameTransformerDelegate
+    Note over Base, Delegate: 3. Delegate manages frame transformation
+    Note right of Delegate: Delegate will call transformer->Transform()<br/>for each encoded frame
 
-    %% Stream Lookup and Configuration
-    Channel->>Channel: find(ssrc) in send_streams_
-    Note over Channel: 5. Stream Located Successfully
-    Channel->>Stream: SetSFrameTransformer(transformer, options)
-
-    %% Stream Configuration Update
-    Note over Channel, Stream: 6. Stream Configuration
-    Stream->>Stream: Update parameters_.config.sframe_transformer
-    Stream->>Stream: Update parameters_.config.sframe_options
-    Note right of Stream: VideoSendStream::Config updated<br/>with SFrame settings
-
-    %% Stream Recreation and Creation Pipeline
-    Note over Stream: 7. Stream Recreation Required
-    Stream->>Stream: RecreateWebRtcStream()
-    Note right of Stream: Stream recreation applies<br/>new SFrame configuration
-
-    %% Video Send Stream Creation Pipeline
-    Stream->>Call: CreateVideoSendStream(parameters_.config)
-    Note over Stream, Call: 8. Call Layer<br/>Creates VideoSendStreamImpl
-
-    Call->>VSImpl: new VideoSendStreamImpl(config)
-    Note over Call, VSImpl: 9. Video Send Stream Implementation
-
-    VSImpl->>RtpVideoSender: Create RtpVideoSender
-    Note over VSImpl, RtpVideoSender: 10. RTP Video Sender Creation<br/>Handles simulcast layers
-
-    RtpVideoSender->>RTPSender: Create RTPSenderVideo instances
-    Note over RtpVideoSender, RTPSender: 11. RTP Sender Video Creation<br/>One per simulcast layer
-
-    RTPSender->>RTPSender: Configure with SFrame settings
-    Note over RTPSender: 12. Final Configuration
-    Note right of RTPSender: RTPSenderVideo now configured<br/>with SFrame transformer<br/>Ready to encrypt frames/packets
-
-    %% Success Response
-    Note over User, RTPSender: 13. Initialization Complete
+    Note over User, Delegate: 4. Initialization Complete<br/>Frames will be encrypted during transmission
 ```
 
-### Key Flow Steps:
+1. **Transformer Creation**: User creates `SFrameFrameTransformer` for frame-level encryption
+2. **Key Configuration**: User configures encryption keys via `SetEncryptionKey()`
+3. **API Call**: User calls `SetFrameTransformer()` to attach the transformer
+4. **Observer Registration**: `RtpSenderBase` registers itself as a negotiation observer with the transformer
+5. **SDP Negotiation**: Transformer immediately requests SFrame SDP attribute, triggering renegotiation
+6. **Delegate Creation**: `RtpSenderVideoFrameTransformerDelegate` is created to handle transformation callbacks
+7. **Encryption Active**: Encoded frames are now encrypted via the transformer before packetization
 
-1. **API Entry Point**: User calls `SetSFrameTransformer()` with transformer and options
-2. **Base Implementation**: `RtpSenderBase` stores the transformer and validates readiness
-3. **Media Channel**: `WebRtcVideoSendChannel` locates the correct stream by SSRC
-4. **Stream Configuration**: `WebRtcVideoSendStream` updates configuration parameters in place
-5. **Stream Recreation**: Existing streams are recreated to apply new SFrame settings
-6. **Creation Pipeline**: Settings flow through Call → VideoSendStreamImpl → RtpVideoSender → RTPSenderVideo
-7. **Ready for Encryption**: RTPSenderVideo is now ready to encrypt frames/packets
+## Packet-Level SFrame Transformer Initialization Flow
 
-Once initialization is complete, the RTPSenderVideo component can perform encryption at two levels based on the configured `SFrameOptions`.
+The following diagram illustrates how SFrame frame transformers are configured in the WebRTC video sender pipeline using `SetFrameTransformer()`.
 
-## C++ API Proposal
+```mermaid
+sequenceDiagram
+    participant User as Application/User Code
+    participant API as RtpSenderInterface
+    participant Base as RtpSenderBase
+    participant Transformer as SFramePacketTransformer
+    participant Delegate as RtpSenderVideoPacketTransformerDelegate
 
-### Basic API Structure
+    Note over User, Delegate: Frame-Level SFrame Transformer Initialization
 
-The integration starts with extending `RtpSenderInterface` to support SFrame transformers.
+    %% Create SFrame Packet Transformer
+    User->>User: Create SFrame Packet Transformer
+    Note right of User: auto transformer =<br/>make_ref_counted<SFramePacketTransformer>()
 
-```cpp
-class RtpSenderInterface : public SFrameTransformerHost {
- public:
-  /**
-   * Sets up SFrame encryption for this RTP sender.
-   * @param sframe_transformer The encryption implementation
-   * @param options Configuration for how SFrame should operate
-   */
-  virtual void SetSFrameTransformer(
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options) = 0;
+    User->>Transformer: SetEncryptionKey(key)
+    Note right of User: Configure encryption keys
 
-  virtual scoped_refptr<SFrameTransformerInterface> GetSFrameTransformer() = 0;
-};
+    %% Set Packet Transformer
+    User->>API: SetPacketTransformer(transformer)
+    Note over User, API: 1. Packet-Level API
+    
+    API->>Base: SetPacketTransformer(transformer)
+    Note over API, Base: 2. RtpSenderBase stores transformer
+    
+    Base->>Delegate: Create RtpSenderVideoPacketTransformerDelegate
+    Note over Base, Delegate: 3. Delegate manages packet transformation
+    Note right of Delegate: Delegate will call transformer->Transform()<br/>for each encoded frame
+
+    Note over User, Delegate: 4. Initialization Complete<br/>Frames will be encrypted during transmission
 ```
+
+1. **Transformer Creation**: User creates `SFramePacketTransformer` for packet-level encryption
+2. **Key Configuration**: User configures encryption keys via `SetEncryptionKey()`
+3. **API Call**: User calls `SetFrameTransformer()` to attach the transformer
+4. **Observer Registration**: `RtpSenderBase` registers itself as a negotiation observer with the transformer
+5. **SDP Negotiation**: Transformer immediately requests SFrame SDP attribute, triggering renegotiation
+6. **Delegate Creation**: `RtpSenderVideoFrameTransformerDelegate` is created to handle transformation callbacks
+7. **Encryption Active**: Encoded frames are now encrypted via the transformer before packetization
 
 ## Implementation Architecture
 
 ### RtpSenderBase
 
-`RtpSenderBase` is the main implementation that both `VideoRtpSender` and `AudioRtpSender` inherit from. Here's how it handles SFrame configuration:
+`RtpSenderBase` is the main implementation that both `VideoRtpSender` and `AudioRtpSender` inherit from. It implements the `FrameTransformerHost` interface to support both frame-level and packet-level transformers.
 
 ```cpp
-class RtpSenderBase: public RtpSenderInterface {
+class RtpSenderBase : public RtpSenderInternal,
+                      public FrameTransformerHost {
  public:
-  /**
-   * Sets up the SFrame transformer and passes the configuration
-   * down to the media channel layer.
-   */
-  void SetSFrameTransformer(
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options) override;
+  // FrameTransformerHost implementation
+  void SetFrameTransformer(
+      scoped_refptr<FrameTransformerInterface> frame_transformer) override;
 
-  scoped_refptr<SFrameTransformerInterface> GetSFrameTransformer() override;
+  void SetPacketTransformer(
+      scoped_refptr<FrameTransformerInterface> packet_transformer) override;
 
  private:
-  // Keeps a reference to the configured SFrame transformer
-  scoped_refptr<SFrameTransformerInterface> sframe_transformer_;
+  // Stored transformer references
+  scoped_refptr<FrameTransformerInterface> frame_transformer_;
+  scoped_refptr<FrameTransformerInterface> packet_transformer_;
 };
 ```
 
-The implementation makes sure SFrame configuration is safely passed to the media channel:
+The implementation manages transformer lifecycle:
 
 ```cpp
-void RtpSenderBase::SetSFrameTransformer(
-    scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-    SFrameOptions options) {
-  sframe_transformer_ = sframe_transformer;
+void RtpSenderBase::SetFrameTransformer(
+    scoped_refptr<FrameTransformerInterface> frame_transformer) {
+  frame_transformer_ = std::move(frame_transformer);
 
-  // Pass configuration to media channel if everything is ready
   if (media_channel_ && ssrc_ && !stopped_) {
     worker_thread_->BlockingCall([&] {
-      media_channel_->SetSFrameTransformer(ssrc_, sframe_transformer, options);
+      media_channel_->SetEncoderToPacketizerFrameTransformer(
+          ssrc_, frame_transformer_);
     });
   }
 }
 
-scoped_refptr<SFrameTransformerInterface> RtpSenderBase::GetSFrameTransformer() {
-  return sframe_transformer_;
-}
-```
+void RtpSenderBase::SetPacketTransformer(
+    scoped_refptr<FrameTransformerInterface> packet_transformer) {
+  packet_transformer_ = std::move(packet_transformer);
 
-## SFrameStreamConfig
-
-The `SFrameStreamConfig` structure consolidates all SFrame-related configuration parameters for media streams. This configuration structure is utilized by both media senders and receivers, with each maintaining its own instance to ensure proper encapsulation of SFrame settings.
-
-The structure contains three primary components: `SFrameOptions` and `SFrameTransformerInterface` are populated through the `SetSFrameTransformer` API call, while the `require_sframe` property is configured separately during SDP negotiation. This separation is necessary to accommodate scenarios where SFrame may be enabled through receiver-side configuration (via SFrameTransform creation) without necessarily having a transformer available on the sender side.
-
-```cpp
-struct SFrameStreamConfig {
-  // SDP negotiated if we should require SFrame
-  bool require_sframe;
-
-  // Options provided with `SetSFrameTransformer`
-  // Should it be optional ? Or simply keep defaults?
-  SFrameOptions options;
-
-  // Transformer
-  scoped_refptr<SFrameTransformerInterface> sframe_transformer;
-};
-```
-
-## Media Channel Layer
-
-### Extending MediaSendChannelInterface
-
-To support SFrame at the media channel level, we need to extend the interface with a new method:
-
-```cpp
-class MediaSendChannelInterface {
- public:
-  /**
-   * Configures SFrame encryption for a specific stream.
-   * @param ssrc The stream identifier
-   * @param sframe_transformer The encryption implementation
-   * @param options How SFrame should operate (per-frame vs per-packet)
-   */
-  virtual void SetSFrameTransformer(
-      uint32_t ssrc,
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options) = 0;
-};
-```
-
-### WebRtcVideoSendChannel Implementation
-
-This is where SFrame configuration gets applied to actual video streams:
-
-```cpp
-class WebRtcVideoSendChannel : public VideoMediaSendChannelInterface {
- public:
-  /**
-   * Finds the right video stream and applies SFrame configuration to it.
-   */
-  void SetSFrameTransformer(
-      uint32_t ssrc,
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options) override;
-};
-```
-
-The implementation looks up the correct stream and handles errors gracefully:
-
-```cpp
-void WebRtcVideoSendChannel::SetSFrameTransformer(
-    uint32_t ssrc,
-    scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-    SFrameOptions options) {
-  RTC_DCHECK_RUN_ON(&thread_checker_);
-
-  auto matching_stream = send_streams_.find(ssrc);
-  if (matching_stream != send_streams_.end()) {
-    matching_stream->second->SetSFrameTransformer(sframe_transformer, options);
-  } else {
-    RTC_LOG(LS_ERROR) << "Could not find stream with SSRC " << ssrc
-                      << " to configure SFrame encryption";
+  if (media_channel_ && ssrc_ != 0) {
+    worker_thread_->BlockingCall([&] {
+      media_channel_->SetPacketTransformer(ssrc_, packet_transformer_);
+    });
   }
 }
 ```
 
-### Individual Stream Configuration
+## Media Channel Layer
 
-Each video stream is represented by a `WebRtcVideoSendStream` object. When SFrame configuration is applied, the stream must be recreated to properly integrate the new encryption settings. The configuration parameters are stored within the `SFrameStreamConfig` structure, which is embedded in the stream's configuration hierarchy for centralized management.
+### WebRtcVideoSendChannel
+
+The `WebRtcVideoSendChannel` class implements the video send channel interface and manages multiple video send streams. It provides methods to configure frame transformers on a per-SSRC basis.
 
 ```cpp
-struct VideoSendStreamParameters {
-  /* Other fields */
-  VideoSendStream::Config config;
-};
+class WebRtcVideoSendChannel : public MediaChannelUtil,
+                               public VideoMediaSendChannelInterface {
+ public:
+  void SetEncoderToPacketizerFrameTransformer(
+      uint32_t ssrc,
+      scoped_refptr<FrameTransformerInterface> frame_transformer) override;
 
-struct VideoSendStream::Config {
-  /* Other fields */
-  SFrameStreamConfig sframe_stream_config;
+  void SetPacketTransformer(
+      uint32_t ssrc,
+      scoped_refptr<FrameTransformerInterface> packet_transformer) override;
+
+ private:
+  std::map<uint32_t, WebRtcVideoSendStream*> send_streams_;
 };
 ```
+
+The implementation looks up the correct stream and delegates the transformer configuration:
+
+```cpp
+void WebRtcVideoSendChannel::SetEncoderToPacketizerFrameTransformer(
+    uint32_t ssrc,
+    scoped_refptr<FrameTransformerInterface> frame_transformer) {
+  RTC_DCHECK_RUN_ON(&thread_checker_);
+  auto matching_stream = send_streams_.find(ssrc);
+  if (matching_stream != send_streams_.end()) {
+    matching_stream->second->SetEncoderToPacketizerFrameTransformer(
+        std::move(frame_transformer));
+  }
+}
+
+void WebRtcVideoSendChannel::SetPacketTransformer(
+    uint32_t ssrc,
+    scoped_refptr<FrameTransformerInterface> packet_transformer) {
+  RTC_DCHECK_RUN_ON(&thread_checker_);
+  auto matching_stream = send_streams_.find(ssrc);
+  if (matching_stream != send_streams_.end()) {
+    matching_stream->second->SetPacketTransformer(packet_transformer);
+  } else {
+    RTC_LOG(LS_ERROR) << "No stream found to attach packet transformer";
+  }
+}
+```
+
+### WebRtcVideoSendStream
+
+Each video stream is represented by a `WebRtcVideoSendStream` object which wraps the internal `VideoSendStream`. Frame transformer configuration is stored in `VideoSendStream::Config` and triggers stream recreation.
 
 ```cpp
 class WebRtcVideoSendStream {
  public:
-  /**
-   * Applies SFrame configuration to this video stream.
-   * This triggers recreation of the underlying WebRTC stream.
-   */
-  void SetSFrameTransformer(
-      scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-      SFrameOptions options);
+  void SetEncoderToPacketizerFrameTransformer(
+      scoped_refptr<FrameTransformerInterface> frame_transformer);
 
-  // Holds configuration of the stream
+  void SetPacketTransformer(
+      scoped_refptr<FrameTransformerInterface> packet_transformer);
+
+ private:
+  void RecreateWebRtcStream();
+  
   VideoSendStreamParameters parameters_;
+  VideoSendStream* stream_;
 };
 ```
 
-Here's how stream recreation works:
+When a frame transformer is set, the stream configuration is updated and the stream is recreated:
 
 ```cpp
-void WebRtcVideoSendChannel::WebRtcVideoSendStream::SetSFrameTransformer(
-    scoped_refptr<SFrameTransformerInterface> sframe_transformer,
-    SFrameOptions options) {
+void WebRtcVideoSendChannel::WebRtcVideoSendStream::
+    SetEncoderToPacketizerFrameTransformer(
+        scoped_refptr<FrameTransformerInterface> frame_transformer) {
   RTC_DCHECK_RUN_ON(&thread_checker_);
+  parameters_.config.frame_transformer = std::move(frame_transformer);
+  if (stream_)
+    RecreateWebRtcStream();
+}
+```
 
-  // Update the stream configuration
-  parameters_.config.sframe_stream_config.sframe_transformer = sframe_transformer;
-  parameters_.config.sframe_stream_config.sframe_options = options;
+When a packet transformer is set, the stream configuration is updated and the stream is recreated:
 
-  // Recreate the stream with new SFrame settings
+```cpp
+void WebRtcVideoSendChannel::WebRtcVideoSendStream::SetPacketTransformer(
+    scoped_refptr<FrameTransformerInterface> packet_transformer) {
+  RTC_DCHECK_RUN_ON(&thread_checker_);
+  parameters_.config.packet_transformer = packet_transformer;
   if (stream_) {
-    RTC_LOG(LS_INFO) << "Recreating video stream to apply SFrame encryption, "
-                     << "SSRC=" << parameters_.config.rtp.ssrcs[0];
+    RTC_LOG(LS_INFO)
+        << "RecreateWebRtcStream (send) because of SetPacketTransformer, ssrc="
+        << parameters_.config.rtp.ssrcs[0];
     RecreateWebRtcStream();
   }
 }
 ```
 
-`RecreateWebRtcStream()` initiates the creation of a new VideoSendStream instance through the `Call` interface, utilizing the configuration parameters contained within `VideoSendStream::Config`.
+### VideoSendStream::Config
 
-### Call::CreateVideoSendStream
+The frame transformer is stored directly in the `VideoSendStream::Config` structure:
 
-Creates a new `VideoSendStreamImpl` instance with the provided configuration from the `WebRtcVideoEngine`.
+```cpp
+struct VideoSendStream::Config {  
+  // Optional frame transformer (encoder to packetizer transformation)
+  scoped_refptr<FrameTransformerInterface> frame_transformer;
+
+  // Optional packet transformer (per-packet transformation)
+  scoped_refptr<FrameTransformerInterface> packet_transformer;
+
+  // ... other fields
+};
+```
 
 ### VideoSendStreamImpl
 
-`VideoSendStreamImpl` utilizes the `RtpTransportControllerSendInterface` to instantiate a `RtpVideoSender`.
+The `VideoSendStreamImpl` is created by the `Call` interface and manages the video encoding and sending pipeline. It creates the `RtpVideoSender` with the frame transformer from the configuration.
+
+```cpp
+class VideoSendStreamImpl : public VideoSendStream,
+                            public BitrateAllocatorObserver,
+                            public VideoStreamEncoderInterface::EncoderSink {
+ public:
+  VideoSendStreamImpl(
+      const Environment& env,
+      int num_cpu_cores,
+      RtcpRttStats* call_stats,
+      RtpTransportControllerSendInterface* transport,
+      Metronome* metronome,
+      BitrateAllocatorInterface* bitrate_allocator,
+      SendDelayStats* send_delay_stats,
+      VideoSendStream::Config config,
+      VideoEncoderConfig encoder_config,
+      const RtpStateMap& suspended_ssrcs,
+      const RtpPayloadStateMap& suspended_payload_states,
+      std::unique_ptr<FecController> fec_controller,
+      std::unique_ptr<VideoStreamEncoderInterface> video_stream_encoder);
+};
+```
 
 ### RtpVideoSender
 
-`RtpVideoSender` creates a collection of `RTPSenderVideo` objects to handle individual simulcast layer streams. `RTPSenderVideo` serves as the final integration point where SFrame encryption operations are performed.
-
-## RTP Sender Video - Where Encryption Happens
-
-### VideoSFrameEncryptor
-
-The `VideoSFrameEncryptor` class provides a clean abstraction layer that encapsulates all SFrame-related encryption operations for video streams. This design promotes better code organization and maintainability by consolidating encryption logic within a dedicated component.
+The `RtpVideoSender` is created with both frame and packet transformers and manages multiple `RTPSenderVideo` instances for simulcast layers.
 
 ```cpp
-class VideoSFrameEncryptor {
+class RtpVideoSender : public RtpVideoSenderInterface,
+                       public VCMProtectionCallback,
+                       public StreamFeedbackObserver {
  public:
-  enum class EncryptionResult {
-    kSuccess,
-    kFailure,
-    kDrop,
-    kSkip,
-  };
-
-  VideoSFrameEncryptor(scoped_refptr<SFrameTransformerInterface> sframe_transformer, SFrameOptions options_);
-
-  ~VideoSFrameEncryptor();
-
-  EncryptionResult MaybeEncryptFrame(VideoCodecType& codec_type,
-                                     ArrayView<const uint8_t> payload);
-
-  EncryptionResult MaybeEncryptPackets(std::vector<std::unique_ptr<RtpPacketToSend>>& packets);
-
+  RtpVideoSender(
+      const Environment& env,
+      TaskQueueBase* transport_queue,
+      const std::map<uint32_t, RtpState>& suspended_ssrcs,
+      const std::map<uint32_t, RtpPayloadState>& states,
+      const RtpConfig& rtp_config,
+      int rtcp_report_interval_ms,
+      Transport* send_transport,
+      const RtpSenderObservers& observers,
+      RtpTransportControllerSendInterface* transport,
+      RateLimiter* retransmission_limiter,
+      std::unique_ptr<FecController> fec_controller,
+      FrameEncryptorInterface* frame_encryptor,
+      const CryptoOptions& crypto_options,
+      scoped_refptr<FrameTransformerInterface> frame_transformer,
+      scoped_refptr<FrameTransformerInterface> packet_transformer);
+  
  private:
-  scoped_refptr<SFrameTransformerInterface> sframe_transformer_;
-
-  SFrameOptions options_;
+  std::vector<std::unique_ptr<RTPSenderVideo>> rtp_streams_;
 };
 ```
 
-The implementation handles all operations required to perform SFrame encryption, providing a standardized interface for both per-frame and per-packet encryption modes.
+The constructor creates RTP stream senders with the transformer configuration, passing transformers down to the individual `RTPSenderVideo` instances.
 
-Example code:
-```cpp
-VideoSFrameEncryptor::EncryptionResult VideoSFrameEncryptor::MaybeEncryptFrame(
-    VideoCodecType& codec_type,
-    ArrayView<const uint8_t> payload) {
-  if (sframe_options_.mode == SFrameMode::kPerPacket) {
-    return EncryptionResult::kSkip;
-  }
-
-  if (!sframe_transformer_) {
-    return EncryptionResult::kDrop;
-  }
-
-  sframe_transformer_->Transform(CopyOnWriteBuffer(payload));
-
-  // Make sure to trigger default packetization for SFrame.
-  codec_type = kVideoCodecSFrame;
-
-  return EncryptionResult::kSuccess;
-}
-```
-
-**Summary**: Manages per-frame SFrame encryption by validating the encryption mode, verifying transformer availability, applying SFrame encryption to the complete frame payload, and updating the codec type to ensure proper SFrame-aware packetization.
-
-```cpp
-VideoSFrameEncryptor::EncryptionResult
-VideoSFrameEncryptor::MaybeEncryptPackets(
-    std::vector<std::unique_ptr<RtpPacketToSend>>& packets) {
-  if (sframe_options_.mode == SFrameMode::kPerFrame) {
-    return EncryptionResult::kSkip;
-  }
-
-  if (!sframe_transformer_) {
-    return EncryptionResult::kDrop;
-  }
-
-  for (const auto& packet : packets) {
-    auto buffer = packet->PayloadBuffer();
-
-    sframe_transformer_->Transform(buffer);
-
-    packet->SetPayload(buffer);
-  }
-
-  // Add SFrame header to the payload
-
-  return EncryptionResult::kSuccess;
-}
-```
-
-**Summary**: Manages per-packet SFrame encryption by validating the encryption mode, verifying transformer availability, iterating through each RTP packet to encrypt payloads individually, updating packet contents with encrypted data, and incorporating necessary SFrame protocol headers.
+## RTPSenderVideo
 
 ### RTPSenderVideo Configuration
 
-The `RTPSenderVideo::Config` structure is extended with additional fields to support SFrame encryption capabilities.
+The `RTPSenderVideo::Config` structure contains frame and packet transformer references that are used to create transformer delegates.
 
 ```cpp
-class RTPSenderVideo : public RTPVideoFrameSenderInterface {
+class RTPSenderVideo : public RTPVideoFrameSenderInterface,
+                       public RTPVideoPacketSenderInterface {
  public:
   struct Config {
-    /* Other configuration fields */
-    bool require_sframe;
-
-    // SFrame encryption interface
-    scoped_refptr<webrtc::SFrameTransformerInterface> sframe_transformer;
-
-    SFrameOptions sframe_options;
+    // Optional transformers
+    scoped_refptr<FrameTransformerInterface> frame_transformer;
+    scoped_refptr<FrameTransformerInterface> packet_transformer;
+    
+    // ... other fields
   };
 
- private:
-  std::unique_ptr<VideoSFrameEncryptor> sframe_encryptor;
+  explicit RTPSenderVideo(const Config& config);
+  virtual ~RTPSenderVideo();
 };
 ```
 
+### Frame Transformer Delegate
 
-### RTPSenderVideo Construction
-
-The `RTPSenderVideo` constructor conditionally instantiates the `VideoSFrameEncryptor` based on the SFrame requirement configuration, ensuring optimal resource utilization.
-
-
+When a frame transformer is configured, `RTPSenderVideo` creates an `RTPSenderVideoFrameTransformerDelegate` to handle the transformation workflow:
 
 ```cpp
-RTPSenderVideo::RTPSenderVideo(const Config& config)
-    : sframe_encryptor(config.require_sframe
-                        ? std::make_unique<VideoSFrameEncryptor>(
-                              config.sframe_transformer,
-                              config.sframe_options)
-                        : nullptr) {} 
+class RTPSenderVideoFrameTransformerDelegate : public TransformedFrameCallback {
+ public:
+  RTPSenderVideoFrameTransformerDelegate(
+      RTPVideoFrameSenderInterface* sender,
+      scoped_refptr<FrameTransformerInterface> frame_transformer,
+      uint32_t ssrc,
+      std::string rid,
+      TaskQueueFactory* send_transport_queue);
+
+  void Init();
+
+  // Transforms encoded frames before packetization
+  bool TransformFrame(int payload_type,
+                      VideoCodecType codec_type,
+                      uint32_t rtp_timestamp,
+                      const EncodedImage& encoded_image,
+                      RTPVideoHeader video_header,
+                      TimeDelta expected_retransmission_time,
+                      const std::vector<uint32_t>& csrcs = {});
+
+  // Callback when transformation completes
+  void OnTransformedFrame(
+      std::unique_ptr<TransformableFrameInterface> frame) override;
+
+  // Sends transformed frame via RTPSenderVideo
+  void SendVideo(std::unique_ptr<TransformableFrameInterface> frame) const;
+};
 ```
 
-### SFrame Transformation Flow in RTPSenderVideo
+The delegate workflow:
+1. **TransformFrame**: Receives encoded frames from the encoder, wraps them in `TransformableFrameInterface`, and passes to the transformer
+2. **Transform**: The `SFrameFrameTransformer` encrypts the frame data
+3. **OnTransformedFrame**: Receives encrypted frame from transformer
+4. **SendVideo**: Sends encrypted frame to `RTPSenderVideo::SendVideo` for packetization
 
-The following diagram shows how encoded video frames flow through RTPSenderVideo and where SFrame encryption is applied:
+### Packet Transformer Delegate
+
+When a packet transformer is configured, `RTPSenderVideo` creates an `RTPSenderPacketTransformerDelegate` to handle packet-level transformation. This operates **after** packetization, transforming individual RTP packets.
+
+```cpp
+class RTPSenderPacketTransformerDelegate : public TransformedFrameCallback {
+ public:
+  RTPSenderPacketTransformerDelegate(
+      RTPVideoPacketSenderInterface* sender,
+      scoped_refptr<FrameTransformerInterface> packet_transformer,
+      uint32_t ssrc);
+
+  void Init();
+
+  // Transforms packets after packetization
+  bool TransformAndSendPackets(
+      std::vector<std::unique_ptr<RtpPacketToSend>> packets,
+      const RTPVideoHeader& video_header,
+      size_t encoder_output_size);
+
+  // Callback when transformation completes
+  void OnTransformedFrame(
+      std::unique_ptr<TransformableFrameInterface> packet) override;
+
+ private:
+  // Tracks packet groups being transformed together
+  struct PacketGroup {
+    size_t total_packets;
+    size_t received_packets = 0;
+    std::vector<std::unique_ptr<RtpPacketToSend>> packets;
+    RTPVideoHeader video_header;
+    size_t encoder_output_size;
+  };
+
+  RTPVideoPacketSenderInterface* sender_;
+  scoped_refptr<FrameTransformerInterface> packet_transformer_;
+  uint32_t ssrc_;
+  std::map<uint64_t, PacketGroup> packet_groups_;
+};
+```
+
+The packet delegate workflow:
+1. **TransformAndSendPackets**: Receives RTP packets after packetization, wraps each packet in `TransformableFrameInterface`
+2. **Transform**: The `SFramePacketTransformer` encrypts each packet's payload individually
+3. **OnTransformedFrame**: Receives encrypted packets from transformer
+4. **Packet Group Reassembly**: Collects all transformed packets belonging to the same frame (tracked by RTP timestamp)
+5. **SendPackets**: Once all packets for a frame are transformed, sends them via `RTPVideoPacketSenderInterface`
+
+### Transformation Flow in RTPSenderVideo
+
+The following diagram shows how encoded video frames flow through RTPSenderVideo with both frame-level and packet-level transformation paths:
 
 ```mermaid
 flowchart TD
     A[Encoded Video Frame] --> B[RTPSenderVideo::SendEncodedImage]
-
-    B[RTPSenderVideo::SendEncodedImage] --> C[RTPSenderVideo::SendVideo]
-
-    C --> E[VideoSFrameEncryptor::<br/>MaybeEncryptFrame]
     
-    E --> E1{Encryption Result}
+    B --> C{frame_transformer_<br/>delegate_?}
     
-    E1 -->|kSuccess| F[Frame Encrypted<br/>Codec Type → SFrame]
-    E1 -->|kSkip| G[No Frame Encryption<br/>Original Codec Type]
-    E1 -->|kDrop/kFailure| Z[Drop Frame<br/>Return False]
+    C -->|Yes - Frame Level| D[RTPSenderVideoFrameTransformerDelegate::<br/>TransformFrame]
+    C -->|No| E[RTPSenderVideo::SendVideo<br/>Direct Path]
     
-    F --> H[RTP Packetization<br/>RtpPacketizerSFrame]
-    G --> H1[RTP Packetization<br/>Codec-Specific Packetizer]
+    D --> F[SFrameFrameTransformer::<br/>Transform Entire Frame]
     
-    H --> I[RTP Packets Created]
-    H1 --> I
+    F --> F1[Detect Video Frame<br/>via MIME Type]
     
-    I --> J[VideoSFrameEncryptor::<br/>MaybeEncryptPackets]
+    F1 --> F2[Cast to TransformableVideoFrameInterface]
     
-    J --> J1{Encryption Result}
+    F2 --> F3[Set Codec Type to kSFrame<br/>metadata.SetCodec VideoCodecType::kSFrame]
     
-    J1 -->|kSuccess| K[Packets Encrypted<br/>Headers Updated]
-    J1 -->|kSkip| L[No Packet Encryption]
-    J1 -->|kDrop/kFailure| Z1[Drop Frame<br/>Return False]
+    F3 --> G[Frame Encrypted]
     
-    K --> M[Send RTP Packets]
-    L --> M
+    G --> H[RTPSenderVideoFrameTransformerDelegate::<br/>OnTransformedFrame]
     
-    M --> N[Encrypted Video Data<br/>Transmitted]
+    H --> I[RTPSenderVideoFrameTransformerDelegate::<br/>SendVideo]
     
-    style E fill:#e1f5fe
+    I --> J[RTPSenderVideo::SendVideo]
+    E --> J
+    
+    J --> K[RTP Packetization]
+    
+    K --> L[RtpPacketizer::Create<br/>Based on Codec Type<br/>Uses kSFrame for SFrame-encrypted video]
+    
+    L --> M[Generate RTP Packets]
+    
+    M --> N{packet_transformer_<br/>delegate_?}
+    
+    N -->|Yes - Packet Level| O[RTPSenderPacketTransformerDelegate::<br/>TransformAndSendPackets]
+    N -->|No| P[RTPSenderVideo::SendPackets]
+    
+    O --> Q[SFramePacketTransformer::<br/>Transform Each Packet]
+    
+    Q --> R[Packets Encrypted]
+    
+    R --> S[RTPSenderPacketTransformerDelegate::<br/>OnTransformedFrame]
+    
+    S --> T{All Packets<br/>Received?}
+    
+    T -->|No| S
+    T -->|Yes| U[RTPSenderPacketTransformerDelegate::<br/>SendPackets]
+    
+    U --> V[RTPSenderVideo::SendPackets]
+    P --> V
+    
+    V --> W[Encrypted Video Data<br/>Transmitted]
+    
+    style D fill:#e1f5fe
     style F fill:#fff3e0
-    style H fill:#fff3e0
-    style J fill:#e1f5fe
-    style K fill:#fff3e0
-    style N fill:#c8e6c9
-    style Z fill:#ffcdd2
-    style Z1 fill:#ffcdd2
+    style H fill:#e1f5fe
+    style O fill:#c8e6c9
+    style Q fill:#a5d6a7
+    style S fill:#c8e6c9
+    style W fill:#ffeb3b
 ```
 
-### RTPSenderVideo Overview
+**Flow Explanation**:
 
-The `RTPSenderVideo` class is where the actual video processing happens. It receives encoded video frames and splits them into RTP packets. This is a good place to add SFrame encryption because:
+1. **Frame Reception**: `SendEncodedImage` receives encoded frame from encoder
+2. **Frame-Level Path** (if configured):
+   - Frame transformer delegate intercepts the encoded frame
+   - **SFrame Encryption Process**:
+     - SFrameFrameTransformer detects video frames via MIME type check (`mime_type.find("video")`)
+     - Casts to `TransformableVideoFrameInterface` for video-specific operations
+     - **Modifies codec type**: Sets `metadata.SetCodec(VideoCodecType::kSFrame)`
+     - This codec change signals RTP packetizer to use SFrame packetization format
+   - Entire frame is encrypted before packetization
+   - Encrypted frame is then packetized normally
+3. **Packetization**: Encoded (possibly encrypted) frame is split into RTP packets
+   - **RtpPacketizer::Create** uses the codec type (now `kSFrame` for SFrame-encrypted video) to select the appropriate packetizer
+   - This ensures SFrame-specific RTP payload formatting
+4. **Packet-Level Path** (if configured):
+   - Packet transformer delegate intercepts RTP packets after packetization
+   - Each packet is encrypted individually
+   - Delegate tracks packet groups and reassembles them after transformation
+5. **Transmission**: Final RTP packets are sent to the network
 
-- **Per-frame encryption** works well here since we have access to complete frames before packetization
-- **Per-packet encryption** can be done after packetization, though this has some architectural trade-offs (more on this later)
+### RTPSenderVideo Processing Flow
 
-### Processing Encoded Frames
-
-When `RTPSenderVideo` receives an encoded frame, it can either process it through the frame transformer pipeline or handle it directly:
+When `RTPSenderVideo` receives an encoded frame, it checks if a frame transformer delegate exists and routes accordingly:
 
 ```cpp
-bool RTPSenderVideo::SendEncodedImage(int payload_type,
-                                      std::optional<VideoCodecType> codec_type,
-                                      uint32_t rtp_timestamp,
-                                      const EncodedImage& encoded_image,
-                                      RTPVideoHeader video_header,
-                                      TimeDelta expected_retransmission_time,
-                                      const std::vector<uint32_t>& csrcs) {
-  // If there's a frame transformer, use it (this handles existing transform logic)
+bool RTPSenderVideo::SendEncodedImage(
+    int payload_type,
+    VideoCodecType codec_type,
+    uint32_t rtp_timestamp,
+    const EncodedImage& encoded_image,
+    RTPVideoHeader video_header,
+    TimeDelta expected_retransmission_time,
+    const std::vector<uint32_t>& csrcs) {
+  
+  // If there's a frame transformer delegate, use frame-level transformation
   if (frame_transformer_delegate_) {
     return frame_transformer_delegate_->TransformFrame(
         payload_type, codec_type, rtp_timestamp, encoded_image, video_header,
         expected_retransmission_time, csrcs);
   }
 
-  // Otherwise, process the frame directly
+  // Otherwise, process the frame directly without frame-level transformation
   return SendVideo(payload_type, codec_type, rtp_timestamp,
                    encoded_image.CaptureTime(), encoded_image,
                    encoded_image.size(), video_header,
@@ -510,129 +549,42 @@ bool RTPSenderVideo::SendEncodedImage(int payload_type,
 }
 ```
 
-### SFrame Encryption Integration
-
-The `SendVideo` method integrates SFrame encryption capabilities by leveraging the `VideoSFrameEncryptor` component. The implementation supports both per-frame and per-packet encryption modes through a structured approach that maintains compatibility with existing packetization workflows:
+The `SendVideo` method handles packetization and packet-level transformation:
 
 ```cpp
-bool RTPSenderVideo::SendVideo(int payload_type,
-                               std::optional<VideoCodecType> codec_type,
-                               uint32_t rtp_timestamp,
-                               Timestamp capture_time,
-                               ArrayView<const uint8_t> payload,
-                               size_t encoder_output_size,
-                               RTPVideoHeader video_header,
-                               TimeDelta expected_retransmission_time,
-                               std::vector<uint32_t> csrcs) {
+bool RTPSenderVideo::SendVideo(
+    int payload_type,
+    VideoCodecType codec_type,
+    uint32_t rtp_timestamp,
+    Timestamp capture_time,
+    ArrayView<const uint8_t> payload,
+    size_t encoder_output_size,
+    RTPVideoHeader video_header,
+    TimeDelta expected_retransmission_time,
+    std::vector<uint32_t> csrcs) {
 
-  // Per-frame encryption: encrypt the complete frame before packetization
- switch (sframe_encryptor->MaybeEncryptFrame(codec_type, payload)) {
-    case RtpSenderSFrameVideo::EncryptionResult::kDrop:
-      // Drop can happen if we do not have keys to encrypt the frame.
-      // Transformer is not set, even though SFrame is configured.
-      return false;
-    case RtpSenderSFrameVideo::EncryptionResult::kSuccess:
-      // Frame has been encrypted, pass to packetizer.
-      break;
-    case RtpSenderSFrameVideo::EncryptionResult::kFailure:
-      // Failure while encrypting, drop frame
-      return false;
-    case RtpSenderSFrameVideo::EncryptionResult::kSkip:
-      // SFrame encryption not attempted (probably per-packet requested), continue with normal packetization.
-      break;
-  } 
-
-  /*
-   * RTP packetization selection based on encryption results:
-   * - Per-frame SFrame: Uses RtpPacketizerSFrame when codec_type is modified to SFrame
-   * - Per-packet SFrame: Uses codec-specific packetizer for original codec type
-   * - Non-encrypted: Uses standard codec-specific packetization
-   */
+  // Create appropriate packetizer based on codec type
   std::unique_ptr<RtpPacketizer> packetizer = RtpPacketizer::Create(
-      GetPacketizationFormat(codec_type, raw_packetization_), payload, limits,
+      GetPacketizationFormat(codec_type, raw_packetization_), 
+      payload, 
+      limits,
       video_header);
 
+  // Generate RTP packets from the encoded frame
   std::vector<std::unique_ptr<RtpPacketToSend>> rtp_packets;
+  while (std::unique_ptr<RtpPacketToSend> packet = packetizer->NextPacket()) {
+    rtp_packets.push_back(std::move(packet));
+  }
 
-  // Per-packet encryption: encrypt each packet individually
-  switch (sframe_encryptor->MaybeEncryptPackets(rtp_packets)) {
-    case RtpSenderSFrameVideo::EncryptionResult::kDrop:
-      // Drop the whole frame if any packet fails to encrypt (probably missing transformer).
-      return false;
-    case RtpSenderSFrameVideo::EncryptionResult::kSuccess:
-      // Packet has been encrypted.
-      break;
-    case RtpSenderSFrameVideo::EncryptionResult::kFailure:
-      // Packet was not encrypted, return.
-      break;
-    case RtpSenderSFrameVideo::EncryptionResult::kSkip:
-      // SFrame encryption not attempted (probably per-frame), continue.
-      break;
-  } 
-
-  // Send the packets out
+  // If there's a packet transformer delegate, use packet-level transformation
+  if (packet_transformer_delegate_) {
+    packet_transformer_delegate_->TransformAndSendPackets(
+        std::move(rtp_packets), video_header, encoder_output_size);
+  } else {
+    // Otherwise, send packets directly without packet-level transformation
+    SendPackets(std::move(rtp_packets), video_header, encoder_output_size);
+  }
+  
+  return true;
 }
-```
-
-### SFrame Packetizer
-
-SFrame encryption requires specialized packetization to accommodate the encrypted payload format. The `RtpPacketizerSFrame` class provides this functionality by extending the standard RTP packetization interface.
-
-```
-class RtpPacketizerSFrame : public RtpPacketizer {
- public:
-  // Initialize with SFrame ciphertext payload.
-  // The payload should contain a complete SFrame ciphertext (header + encrypted data + auth tag).
-  RtpPacketizerSFrame(ArrayView<const uint8_t> payload,
-                      PayloadSizeLimits limits);
-
-  RtpPacketizerSFrame(const RtpPacketizerSFrame&) = delete;
-  RtpPacketizerSFrame& operator=(const RtpPacketizerSFrame&) = delete;
-
-  ~RtpPacketizerSFrame() override;
-
-  size_t NumPackets() const override;
-
-  bool NextPacket(RtpPacketToSend* rtp_packet) override;
-
- private:
-  // SFrame RTP header size is always 1 byte
-  static constexpr size_t kSFrameRtpHeaderSize = 1;
-  
-  // The remaining SFrame payload to be packetized
-  ArrayView<const uint8_t> remaining_payload_;
-  
-  // Sizes of payload data for each packet (excluding SFrame RTP header)
-  std::vector<int> payload_sizes_;
-  
-  // Iterator pointing to the current packet size
-  std::vector<int>::const_iterator current_packet_;
-  
-  // SFrame RTP header (1 byte with S/E flags)
-  uint8_t sframe_header_;
-}; 
-```
-
-The packetizer operates similarly to `GenericRtpPacketizer` since SFrame utilizes generic packetization principles. The primary distinction is the addition of an SFrame-specific header at the beginning of each RTP payload, providing the necessary protocol information for proper decryption at the receiver.
-
-```
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|V=2|P|X|  CC   |M|     PT      |       sequence number         |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           timestamp                           |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|           synchronization source (SSRC) identifier            |
-+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
-|            contributing source (CSRC) identifiers             |
-|                             ....                              |
-+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
-|S E x x x x x x|                                               |
-|                                                               |
-:                       SFrame payload                          :
-|                                                               |
-|                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                               :    OPTIONAL RTP padding       |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ```

--- a/webrtc-sframe-transformers.md
+++ b/webrtc-sframe-transformers.md
@@ -1,0 +1,200 @@
+# SFrame Transformers Architecture
+
+This document describes the architecture and functionality of the SFrame encryption transformers in the WebRTC implementation.
+
+## Overview
+
+The SFrame (Secure Frame) encryption system provides two transformation approaches:
+
+1. **Frame-level transformation** (`SFrameFrameTransformer`) - Encrypts entire media frames before packetization
+2. **Packet-level transformation** (`SFramePacketTransformer`) - Encrypts individual RTP packets after packetization
+
+Both transformers implement the `FrameTransformerInterface` and follow the RFC draft-ietf-avtcore-rtp-sframe specification.
+
+## SFrameFrameTransformer
+
+### Purpose
+
+`SFrameFrameTransformer` operates on complete media frames before they are fragmented into RTP packets.
+
+### Architecture
+
+```
+TransformableFrameInterface (frame)
+    |
+    v
+SFrameFrameTransformer::Transform()
+    |
+    v
+EncryptFrame()
+    |
+    +-- Detect frame type via MIME type
+    |   (mime_type.find("video") != std::string::npos)
+    |
+    +-- [Video Frame Path]
+    |   Cast to TransformableVideoFrameInterface
+    |   Modify metadata: SetCodec(VideoCodecType::kSFrame)
+    |
+    v
+Return encrypted frame
+    |
+    v
+SFrame RTP Packetizer (uses kSFrame codec for video)
+    |
+    v
+Send encrypted packets
+```
+
+### Key Implementation Details
+
+#### Video Frame Detection
+
+The transformer detects video frames by examining the MIME type string:
+
+```cpp
+const std::string& mime_type = frame->GetMimeType();
+bool is_video = mime_type.find("video") != std::string::npos;
+```
+
+#### Video Frame Codec Modification
+
+For video frames, the transformer:
+1. Casts to `TransformableVideoFrameInterface*`
+2. Accesses the video metadata
+3. Sets the codec type to `kSFrame`
+
+```cpp
+auto* video_frame = static_cast<TransformableVideoFrameInterface*>(frame.get());
+VideoFrameMetadata& metadata = video_frame->GetMetadata();
+metadata.SetCodec(VideoCodecType::kSFrame);
+```
+
+This codec modification ensures that when the frame returns to the WebRTC pipeline, the RTP packetizer will use the SFrame codec configuration.
+
+### Code Example
+
+```cpp
+void SFrameFrameTransformer::Transform(
+    std::unique_ptr<TransformableFrameInterface> frame) {
+  MutexLock lock(&callback_mutex_);
+  
+  if (!callback_) {
+    return;
+  }
+
+  auto encrypted_frame = EncryptFrame(std::move(frame));
+  if (encrypted_frame) {
+    callback_->OnTransformedFrame(std::move(encrypted_frame));
+  }
+}
+
+std::unique_ptr<TransformableFrameInterface>
+SFrameFrameTransformer::EncryptFrame(
+    std::unique_ptr<TransformableFrameInterface> frame) {
+  // TODO: Actual SFrame encryption
+  
+  const std::string& mime_type = frame->GetMimeType();
+  
+  if (mime_type.find("video") != std::string::npos) {
+    // Video frame: modify codec type for proper packetization
+    auto* video_frame = static_cast<TransformableVideoFrameInterface*>(frame.get());
+    VideoFrameMetadata& metadata = video_frame->GetMetadata();
+    metadata.SetCodec(VideoCodecType::kSFrame);
+  } else {
+    // Audio processing to be defined
+  }
+  
+  return frame;
+}
+```
+
+## SFramePacketTransformer
+
+### Purpose
+
+`SFramePacketTransformer` operates on individual RTP packets after packetization.
+
+### Architecture
+
+```
+TransformableFrameInterface (RTP packet)
+    |
+    v
+SFramePacketTransformer::Transform()
+    |
+    v
+EncryptPacket()
+    |
+    +-- Get packet payload
+    |
+    +-- Encrypt payload (TODO)
+    |   Per RFC 9605:
+    |   - Encrypt with SFrame
+    |   - Add SFrame header (1-17 bytes)
+    |   - Add auth tag (up to 16 bytes)
+    |
+    +-- Prepend SFrame RTP header byte
+    |   0xC0 = 11000000 (S=1, E=1)
+    |   Indicates complete SFrame in single packet
+    |
+    v
+Return encrypted packet
+    |
+    v
+RTP Sender (sends packet on network)
+```
+
+### Key Implementation Details
+
+#### SFrame RTP Header Byte
+
+The transformer prepends a single byte to indicate SFrame packet boundaries:
+
+```cpp
+// S=1, E=1 (0xC0 = 11000000)
+// Complete SFrame ciphertext in a single packet
+constexpr uint8_t kSFrameHeaderSinglePacket = 0xC0;
+```
+
+Bit layout:
+- **S bit (Start)**: Set to 1 for first packet of SFrame
+- **E bit (End)**: Set to 1 for last packet of SFrame
+- For single-packet frames: Both bits are 1 (0xC0)
+
+### Code Example
+
+```cpp
+void SFramePacketTransformer::Transform(
+    std::unique_ptr<TransformableFrameInterface> packet) {
+  MutexLock lock(&callback_mutex_);
+  
+  if (!callback_) {
+    return;
+  }
+
+  auto encrypted_packet = EncryptPacket(std::move(packet));
+  if (encrypted_packet) {
+    callback_->OnTransformedFrame(std::move(encrypted_packet));
+  }
+}
+
+std::unique_ptr<TransformableFrameInterface>
+SFramePacketTransformer::EncryptPacket(
+    std::unique_ptr<TransformableFrameInterface> packet) {
+  ArrayView<const uint8_t> payload = packet->GetData();
+  
+  std::vector<uint8_t> sframe_packet;
+  sframe_packet.reserve(1 + payload.size());
+  
+  // Prepend SFrame RTP header byte: S=1, E=1
+  sframe_packet.push_back(kSFrameHeaderSinglePacket);
+  
+  // Append encrypted payload (TODO: actual encryption)
+  sframe_packet.insert(sframe_packet.end(), payload.begin(), payload.end());
+  
+  packet->SetData(ArrayView<const uint8_t>(sframe_packet.data(), 
+                                            sframe_packet.size()));
+  
+  return packet;
+}
+```


### PR DESCRIPTION
This pull request introduces significant architectural changes to the SFrame encryption integration in WebRTC and extends the Blink RTCRtpScriptTransform to support both frame-level and packet-level transformations. The main focus is on unifying the transformer interfaces, improving flexibility for encryption granularity, and ensuring compatibility between native and JavaScript APIs. The changes also update documentation to reflect the new architecture and integration patterns.

### SFrame Transformer Architecture Updates

**Core interface changes:**
* The previous `SFrameTransformerHost` interface is replaced by a new `FrameTransformerHost`, which now supports both frame-level and packet-level transformers via `SetFrameTransformer()` and `SetPacketTransformer()` methods. This enables more granular control over encryption and transformation at different stages of media processing.
* The `RtpSenderInterface` and `RtpReceiverInterface` are updated to inherit from `FrameTransformerHost`, providing the ability to set both frame and packet transformers, aligning with the new architecture.

**Documentation and API surface:**
* The README is refactored to document the new transformer architecture, removing outdated JavaScript API details and clarifying how SFrame encryption is injected and configured at both the sender and receiver levels.

### Blink RTCRtpScriptTransform Extension

**Dual transformer support:**
* `RTCRtpScriptTransform` and its associated C++ implementation are extended to support both frame-level and packet-level transformer brokers, allowing custom processing of encoded frames and packets through Web Workers.
* The method `CreateVideoUnderlyingSourceAndSink` now accepts both frame and packet transformer brokers, and state management is updated to track these separately.
* The worker-side `RTCRtpScriptTransformer` is also updated to handle dual transformer setup, enabling flexible transformation features for video 