### PR TITLE
Dedicated API for sframe on sender/receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,41 +18,43 @@ sequenceDiagram
     participant T as RtpTransceiver
     participant S as RtpSender
     participant R as RtpReceiver
+    participant SendPipeline as Send Pipeline
+    participant RecvPipeline as Receive Pipeline
     participant EncHandle as Encrypter Handle
     participant DecHandle as Decrypter Handle
 
     Note over App,DecHandle: SFrame Enablement Flow
 
     App->>S: CreateSframeEncrypterOrError(options)
-    Note over S: Creates internal SFrame encrypter<br/>Installs encrypter in send pipeline
-    S->>T: Notify SFrame enabled via observer
-    Note over T: Marks SFrame as enabled
-    T-->>S: RTCError::OK()
-    S-->>App: Encrypter handle (or error)
-    App->>EncHandle: Store key management handle
+    S->>T: TryToEnableSframe()
+    T-->>S: OK
+    Note over S: Create SframeEncrypterImpl
+    S->>SendPipeline: Install encrypter (worker thread)
+    S-->>App: Return key management handle
+    App->>EncHandle: Store handle
 
     App->>R: CreateSframeDecrypterOrError(options)
-    Note over R: Creates internal SFrame decrypter<br/>Installs decrypter in receive pipeline
-    R->>T: Notify SFrame enabled via observer
-    Note over T: Already enabled, returns OK
-    T-->>R: RTCError::OK()
-    R-->>App: Decrypter handle (or error)
-    App->>DecHandle: Store key management handle
+    R->>T: TryToEnableSframe()
+    T-->>R: OK (already enabled)
+    Note over R: Create SframeDecrypterImpl
+    R->>RecvPipeline: Install decrypter (worker thread)
+    R-->>App: Return key management handle
+    App->>DecHandle: Store handle
 
     Note over T: Triggers onnegotiationneeded
     T->>App: onnegotiationneeded event
 
     Note over App: Offer/answer exchange includes a=sframe
 
-    Note over App,DecHandle: Key Management
+    Note over App,DecHandle: Key Management (via handles)
 
-    App->>EncHandle: Set encryption key
-    Note over EncHandle: Encryption key set on worker thread
+    App->>EncHandle: SetEncryptionKey(key_id, material)
+    EncHandle->>SendPipeline: Key applied (worker thread)
 
-    App->>DecHandle: Add decryption key
-    Note over DecHandle: Decryption key added on worker thread
+    App->>DecHandle: AddDecryptionKey(key_id, material)
+    DecHandle->>RecvPipeline: Key applied (worker thread)
 
-    Note over App,DecHandle: ✓ SFrame encryption/decryption enabled in media pipeline
+    Note over SendPipeline,RecvPipeline: ✓ Encryption/decryption active in media pipeline
 ```
 
 ## Public API
@@ -149,38 +151,38 @@ Creates an internal SFrame decrypter, installs it in the receive pipeline, notif
 
 ## Internal Architecture
 
-### SframeStateObserver
+### SframeEnablementDelegate
 
-When `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is called, the sender/receiver notifies its transceiver via the `SframeStateObserver` callback. This follows the `SetStreamsObserver` pattern used throughout libwebrtc — a raw pointer to an observer interface, injected via constructor and stored as a `const` member.
+When `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is called, the sender/receiver notifies its transceiver via the `SframeEnablementDelegate` callback. This follows the `SetStreamsObserver` pattern used throughout libwebrtc — a raw pointer to an observer interface, injected via constructor and stored as a `const` member.
 
 ```mermaid
 classDiagram
-    class SframeStateObserver {
+    class SframeEnablementDelegate {
         <<interface>>
-        +TryEnableSframe() RTCError
+        +TryToEnableSframe() RTCError
     }
 
     class RtpTransceiver {
         -sframe enabled state: optional bool
-        +TryEnableSframe() RTCError
+        +TryToEnableSframe() RTCError
     }
 
     class RtpSenderBase {
-        -state observer: SframeStateObserver* const
+        -state observer: SframeEnablementDelegate* const
     }
 
     class RtpReceiverBase {
-        -state observer: SframeStateObserver* const
+        -state observer: SframeEnablementDelegate* const
     }
 
-    SframeStateObserver <|.. RtpTransceiver
-    RtpSenderBase --> SframeStateObserver : notifies
-    RtpReceiverBase --> SframeStateObserver : notifies
+    SframeEnablementDelegate <|.. RtpTransceiver
+    RtpSenderBase --> SframeEnablementDelegate : notifies
+    RtpReceiverBase --> SframeEnablementDelegate : notifies
 ```
 
 **Transceiver state machine:**
 
-| SFrame enabled state | Meaning | `TryEnableSframe()` result |
+| SFrame enabled state | Meaning | `TryToEnableSframe()` result |
 |---|---|---|
 | Not yet decided | SFrame has not been enabled or disabled | Sets to enabled, returns OK |
 | Enabled | SFrame is enabled on this transceiver | Returns OK (idempotent) |
@@ -194,10 +196,10 @@ The transceiver's SFrame enabled state is used during SDP generation to determin
 sequenceDiagram
     participant App as Application
     participant Sender as RtpSenderBase
-    participant Observer as SframeStateObserver (Transceiver)
+    participant Observer as SframeEnablementDelegate (Transceiver)
 
     App->>Sender: CreateSframeEncrypterOrError(options)
-    Sender->>Observer: TryEnableSframe()
+    Sender->>Observer: TryToEnableSframe()
     Observer->>Observer: Check SFrame enabled state
 
     alt SFrame not yet decided
@@ -273,14 +275,14 @@ When the application calls `CreateSframeEncrypterOrError`, the sender:
 sequenceDiagram
     participant App as Application
     participant Sender as RtpSenderBase
-    participant Observer as SframeStateObserver
+    participant Observer as SframeEnablementDelegate
     participant Encrypter as SframeEncrypterImpl
     participant Proxy as SframeEncrypterProxy
     participant Pipeline as Send Pipeline
 
     App->>Sender: CreateSframeEncrypterOrError(options)
 
-    Sender->>Observer: TryEnableSframe()
+    Sender->>Observer: TryToEnableSframe()
     Note over Observer: Mark SFrame as enabled
     Observer->>App: Trigger onnegotiationneeded
     Observer-->>Sender: RTCError::OK()
@@ -305,14 +307,14 @@ sequenceDiagram
 sequenceDiagram
     participant App as Application
     participant Receiver as RtpReceiverBase
-    participant Observer as SframeStateObserver
+    participant Observer as SframeEnablementDelegate
     participant Decrypter as SframeDecrypterImpl
     participant Proxy as SframeDecrypterProxy
     participant Pipeline as Receive Pipeline
 
     App->>Receiver: CreateSframeDecrypterOrError(options)
 
-    Receiver->>Observer: TryEnableSframe()
+    Receiver->>Observer: TryToEnableSframe()
     Note over Observer: Mark SFrame as enabled
     Observer->>App: Trigger onnegotiationneeded
     Observer-->>Receiver: RTCError::OK()
@@ -330,6 +332,165 @@ sequenceDiagram
 
     Receiver-->>App: RTCErrorOr<scoped_refptr<SframeDecrypterInterface>>(proxy)
 ```
+
+## Encrypter/Decrypter Propagation
+
+This section describes how the internally created `SframeEncrypterImpl` and `SframeDecrypterImpl` are propagated from the RtpSender/RtpReceiver down to the actual media pipeline actors that perform encryption and decryption.
+
+### Design Principle
+
+The application never sees or touches the internal encrypter/decrypter implementation. Instead:
+
+1. **RtpSender/RtpReceiver creates** the internal `SframeEncrypterImpl`/`SframeDecrypterImpl`
+2. **RtpSender/RtpReceiver installs** it into the media send/receive pipeline on the worker thread
+3. **RtpSender/RtpReceiver returns** a key management handle (the `SframeEncrypterInterface`/`SframeDecrypterInterface` ref-counted proxy) to the application
+
+The application only interacts with the handle for key management. The actual encryption/decryption happens internally in the media pipeline, invisible to the caller.
+
+### Encrypter Propagation (RtpSender → Send Pipeline)
+
+When `CreateSframeEncrypterOrError` is called on the RtpSender, the encrypter is created and pushed down to the send channel where it intercepts frames or packets depending on the configured mode.
+
+```mermaid
+flowchart TD
+    subgraph API Layer
+        App[Application]
+        SenderAPI[RtpSender]
+    end
+
+    subgraph Internal - Signaling Thread
+        SenderAPI -->|1. CreateSframeEncrypterOrError| Create[Create SframeEncrypterImpl]
+        Create -->|2. Notify| Delegate[SframeEnablementDelegate\nRtpTransceiver]
+    end
+
+    subgraph Internal - Worker Thread
+        Create -->|3. BlockingCall| Install[Install encrypter into\nMediaSendChannel]
+        Install --> SendChannel[MediaSendChannelInterface]
+
+        subgraph Video Path
+            SendChannel --> VSS[VideoSendStream]
+            VSS --> VEncoder[Video Encoder]
+            VEncoder -->|Encoded frame| EncryptPoint_V[SframeEncrypterImpl\nEncrypt frame/packet]
+            EncryptPoint_V --> Packetizer[Packetizer]
+            Packetizer --> Network_V[Network]
+        end
+
+        subgraph Audio Path
+            SendChannel --> ASS[AudioSendStream]
+            ASS --> AEncoder[Audio Encoder]
+            AEncoder -->|Encoded frame| EncryptPoint_A[SframeEncrypterImpl\nEncrypt frame/packet]
+            EncryptPoint_A --> RtpPacketizer[RTP Packetizer]
+            RtpPacketizer --> Network_A[Network]
+        end
+    end
+
+    subgraph Returned to App
+        Create -->|4. Return handle| Handle[SframeEncrypterInterface\nkey management proxy]
+        Handle -->|SetEncryptionKey| EncryptPoint_V
+        Handle -->|SetEncryptionKey| EncryptPoint_A
+    end
+
+    App -->|Calls| SenderAPI
+    App -->|Uses handle for keys| Handle
+
+    style EncryptPoint_V fill:#f96,stroke:#333
+    style EncryptPoint_A fill:#f96,stroke:#333
+    style Handle fill:#6f9,stroke:#333
+```
+
+**Step-by-step:**
+
+| Step | Thread | Action |
+|------|--------|--------|
+| 1 | Signaling | App calls `sender->CreateSframeEncrypterOrError(init)` |
+| 2 | Signaling | RtpSender notifies transceiver via `SframeEnablementDelegate::TryToEnableSframe()` |
+| 3 | Worker (BlockingCall) | RtpSender creates `SframeEncrypterImpl` and installs it into the `MediaSendChannelInterface` |
+| 4 | Signaling | RtpSender wraps the impl in a thread-safe proxy and returns the handle to the app |
+
+After installation, the `SframeEncrypterImpl` lives on the worker thread and is invoked by the send pipeline at the appropriate point (before packetization for per-frame mode, after packetization for per-packet mode). The application only interacts with it through the returned proxy handle for key management.
+
+### Decrypter Propagation (RtpReceiver → Receive Pipeline)
+
+When `CreateSframeDecrypterOrError` is called on the RtpReceiver, the decrypter is created and pushed down to the receive channel where it intercepts packets or frames depending on the mode signaled in the SFrame header.
+
+```mermaid
+flowchart TD
+    subgraph API Layer
+        App[Application]
+        ReceiverAPI[RtpReceiver]
+    end
+
+    subgraph Internal - Signaling Thread
+        ReceiverAPI -->|1. CreateSframeDecrypterOrError| Create[Create SframeDecrypterImpl]
+        Create -->|2. Notify| Delegate[SframeEnablementDelegate\nRtpTransceiver]
+    end
+
+    subgraph Internal - Worker Thread
+        Create -->|3. BlockingCall| Install[Install decrypter into\nMediaReceiveChannel]
+        Install --> RecvChannel[MediaReceiveChannelInterface]
+
+        subgraph Video Path
+            Network_V[Network] --> VRS[VideoReceiveStream]
+            VRS -->|RTP packets| DecryptPoint_V[SframeDecrypterImpl\nDecrypt packet/frame]
+            DecryptPoint_V --> Depacketizer[Depacketizer]
+            Depacketizer --> VDecoder[Video Decoder]
+        end
+
+        subgraph Audio Path
+            Network_A[Network] --> ARS[AudioReceiveStream]
+            ARS -->|RTP packets| DecryptPoint_A[SframeDecrypterImpl\nDecrypt packet/frame]
+            DecryptPoint_A --> AudioDepacketizer[Audio Depacketizer]
+            AudioDepacketizer --> ADecoder[Audio Decoder]
+        end
+    end
+
+    subgraph Returned to App
+        Create -->|4. Return handle| Handle[SframeDecrypterInterface\nkey management proxy]
+        Handle -->|AddDecryptionKey\nRemoveDecryptionKey| DecryptPoint_V
+        Handle -->|AddDecryptionKey\nRemoveDecryptionKey| DecryptPoint_A
+    end
+
+    App -->|Calls| ReceiverAPI
+    App -->|Uses handle for keys| Handle
+
+    style DecryptPoint_V fill:#69f,stroke:#333
+    style DecryptPoint_A fill:#69f,stroke:#333
+    style Handle fill:#6f9,stroke:#333
+```
+
+**Step-by-step:**
+
+| Step | Thread | Action |
+|------|--------|--------|
+| 1 | Signaling | App calls `receiver->CreateSframeDecrypterOrError(init)` |
+| 2 | Signaling | RtpReceiver notifies transceiver via `SframeEnablementDelegate::TryToEnableSframe()` |
+| 3 | Worker (BlockingCall) | RtpReceiver creates `SframeDecrypterImpl` and installs it into the `MediaReceiveChannelInterface` |
+| 4 | Signaling | RtpReceiver wraps the impl in a thread-safe proxy and returns the handle to the app |
+
+After installation, the `SframeDecrypterImpl` lives on the worker thread and is invoked by the receive pipeline at the appropriate point (before depacketization for per-packet mode, after depacketization for per-frame mode). The application only interacts with it through the returned proxy handle for key management.
+
+### Ownership Model
+
+```mermaid
+flowchart LR
+    subgraph Ownership
+        direction TB
+        Impl[SframeEncrypterImpl / SframeDecrypterImpl\nscoped_refptr - shared ownership]
+        Pipeline[MediaSendChannel / MediaReceiveChannel\nholds scoped_refptr]
+        Proxy[Proxy returned to App\nholds scoped_refptr]
+    end
+
+    Impl --- Pipeline
+    Impl --- Proxy
+
+    style Impl fill:#ffd,stroke:#333
+```
+
+The internal impl is ref-counted (`RefCountInterface`). Two parties hold references:
+- **The media channel** (worker thread) — uses the impl for actual encryption/decryption
+- **The proxy handle** (returned to the app) — uses the impl for key management calls, marshaled to the worker thread
+
+This ensures the impl stays alive as long as either the pipeline or the application needs it. When both release their references, the impl is destroyed.
 
 ## Key Management
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ SFrame encryption can be applied at two levels:
 - **Per-frame** (`SframeMode::kPerFrame`): Encrypts complete video/audio frames before packetization
 - **Per-packet** (`SframeMode::kPerPacket`): Encrypts individual RTP packets after packetization
 
-Both modes are activated through the same public API on `RtpSenderInterface` and `RtpReceiverInterface`. The application creates an SFrame encrypter or decrypter by calling a method on the sender or receiver, receives a key management handle, and the internal pipeline handles transformer installation and SDP negotiation automatically.
+Both modes are enabled through the same public API on `RtpSenderInterface` and `RtpReceiverInterface`. The application creates an SFrame encrypter or decrypter by calling a method on the sender or receiver, receives a key management handle, and the internal pipeline handles encrypter/decrypter installation and SDP negotiation automatically.
 
 ## Architecture Overview
 
@@ -18,23 +18,25 @@ sequenceDiagram
     participant T as RtpTransceiver
     participant S as RtpSender
     participant R as RtpReceiver
-    participant EncHandle as SframeEncrypterInterface
-    participant DecHandle as SframeDecrypterInterface
+    participant EncHandle as Encrypter Handle
+    participant DecHandle as Decrypter Handle
 
-    Note over App,DecHandle: SFrame Activation Flow
+    Note over App,DecHandle: SFrame Enablement Flow
 
     App->>S: CreateSframeEncrypterOrError(options)
-    Note over S: Creates internal SFrame transformer<br/>Installs transformer in send pipeline
-    S->>T: OnSframeActivated() via observer
-    Note over T: Sets sframe_activated_ = true
-    S-->>App: RTCErrorOr<SframeEncrypterInterface>
+    Note over S: Creates internal SFrame encrypter<br/>Installs encrypter in send pipeline
+    S->>T: Notify SFrame enabled via observer
+    Note over T: Marks SFrame as enabled
+    T-->>S: RTCError::OK()
+    S-->>App: Encrypter handle (or error)
     App->>EncHandle: Store key management handle
 
     App->>R: CreateSframeDecrypterOrError(options)
-    Note over R: Creates internal SFrame transformer<br/>Installs transformer in receive pipeline
-    R->>T: OnSframeActivated() via observer
-    Note over T: Already activated, returns OK
-    R-->>App: RTCErrorOr<SframeDecrypterInterface>
+    Note over R: Creates internal SFrame decrypter<br/>Installs decrypter in receive pipeline
+    R->>T: Notify SFrame enabled via observer
+    Note over T: Already enabled, returns OK
+    T-->>R: RTCError::OK()
+    R-->>App: Decrypter handle (or error)
     App->>DecHandle: Store key management handle
 
     Note over T: Triggers onnegotiationneeded
@@ -44,13 +46,13 @@ sequenceDiagram
 
     Note over App,DecHandle: Key Management
 
-    App->>EncHandle: SetEncryptionKey(key_id, key_material)
+    App->>EncHandle: Set encryption key
     Note over EncHandle: Encryption key set on worker thread
 
-    App->>DecHandle: AddDecryptionKey(key_id, key_material)
+    App->>DecHandle: Add decryption key
     Note over DecHandle: Decryption key added on worker thread
 
-    Note over App,DecHandle: ✓ SFrame encryption/decryption active in media pipeline
+    Note over App,DecHandle: ✓ SFrame encryption/decryption enabled in media pipeline
 ```
 
 ## Public API
@@ -91,9 +93,7 @@ classDiagram
     RefCountInterface <|-- SframeEncrypterInterface
 ```
 
-The encrypter init carries both `mode` (per-frame or per-packet) and `cipher_suite`. The mode determines which internal transformer is created and how the send pipeline processes frames.
-
-The `key_material` parameter is the SFrame `base_key` — raw key bytes that the SFrame library uses as input to HKDF for deriving the actual encryption keys (per RFC 9605 §4.4).
+The encrypter init carries both `mode` (per-frame or per-packet) and `cipher_suite`. The mode determines how the send pipeline processes frames — either encrypting complete frames before packetization or encrypting individual packets after packetization. The `cipher_suite` selects the cryptographic algorithm used for encryption.
 
 ### SFrame Decrypter Configuration and Interface (`api/sframe/sframe_decrypter_interface.h`)
 
@@ -113,7 +113,9 @@ classDiagram
     RefCountInterface <|-- SframeDecrypterInterface
 ```
 
-The decrypter init carries only `cipher_suite` — the mode (per-frame or per-packet) is inferred from the received SFrame payload descriptor's T bit. The decrypter supports multiple simultaneous keys to handle key rotation scenarios, where new keys are added before old keys are removed.
+The decrypter init carries only `cipher_suite` — the mode (per-frame or per-packet) is automatically determined from the received encrypted data. The decrypter supports multiple simultaneous keys to handle key rotation scenarios, where new keys are added before old keys are removed.
+
+> **Note:** The SFrame header contains a `T` bit that indicates whether the payload is an encrypted full frame (`T=1`) or an encrypted packet (`T=0`). The decrypter uses this bit to automatically select the correct decryption path without requiring the application to specify the mode.
 
 ### API on RtpSenderInterface (`api/rtp_sender_interface.h`)
 
@@ -125,11 +127,10 @@ CreateSframeEncrypterOrError(const SframeEncrypterInit& options) {
 }
 ```
 
-Creates an internal SFrame encrypter, installs the appropriate transformer in the send pipeline, notifies the transceiver of SFrame activation, and returns a key management handle. The returned `SframeEncrypterInterface` is used solely for key management (`SetEncryptionKey`). Can only be called once per sender — subsequent calls return an error.
+Creates an internal SFrame encrypter, installs it in the send pipeline, notifies the transceiver of SFrame enablement, and returns a key management handle. The returned `SframeEncrypterInterface` is used solely for key management (`SetEncryptionKey`). Can only be called once per sender — subsequent calls return an error.
 
 **Errors:**
-- `UNSUPPORTED_OPERATION`: SFrame not yet implemented (stub)
-- `INVALID_MODIFICATION`: SFrame already activated on this transceiver
+- `INVALID_MODIFICATION`: SFrame negotiation has already been disabled on this transceiver (SFrame can only be enabled during the initial offer/answer exchange)
 
 ### API on RtpReceiverInterface (`api/rtp_receiver_interface.h`)
 
@@ -141,51 +142,51 @@ CreateSframeDecrypterOrError(const SframeDecrypterInit& options) {
 }
 ```
 
-Creates an internal SFrame decrypter, installs the appropriate transformer in the receive pipeline, notifies the transceiver of SFrame activation, and returns a key management handle. The returned `SframeDecrypterInterface` is used for key management (`AddDecryptionKey`, `RemoveDecryptionKey`). Can only be called once per receiver — subsequent calls return an error.
+Creates an internal SFrame decrypter, installs it in the receive pipeline, notifies the transceiver of SFrame enablement, and returns a key management handle. The returned `SframeDecrypterInterface` is used for key management (`AddDecryptionKey`, `RemoveDecryptionKey`). Can only be called once per receiver — subsequent calls return an error.
 
 **Errors:**
-- `UNSUPPORTED_OPERATION`: SFrame not yet implemented (stub)
-- `INVALID_MODIFICATION`: SFrame already activated on this transceiver
+- `INVALID_MODIFICATION`: SFrame negotiation has already been disabled on this transceiver (SFrame can only be enabled during the initial offer/answer exchange)
 
 ## Internal Architecture
 
-### SframeActivationObserver
+### SframeStateObserver
 
-When `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is called, the sender/receiver notifies its transceiver via the `SframeActivationObserver` callback. This follows the `SetStreamsObserver` pattern used throughout libwebrtc — a raw pointer to an observer interface, injected via constructor and stored as a `const` member.
+When `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is called, the sender/receiver notifies its transceiver via the `SframeStateObserver` callback. This follows the `SetStreamsObserver` pattern used throughout libwebrtc — a raw pointer to an observer interface, injected via constructor and stored as a `const` member.
 
 ```mermaid
 classDiagram
-    class SframeActivationObserver {
+    class SframeStateObserver {
         <<interface>>
-        +OnSframeActivated() RTCError
+        +TryEnableSframe() RTCError
     }
 
     class RtpTransceiver {
-        -sframe_activated_: std::optional~bool~
-        +OnSframeActivated() RTCError
+        -sframe enabled state: optional bool
+        +TryEnableSframe() RTCError
     }
 
     class RtpSenderBase {
-        -sframe_activation_observer_: SframeActivationObserver* const
+        -state observer: SframeStateObserver* const
     }
 
     class RtpReceiverBase {
-        -sframe_activation_observer_: SframeActivationObserver* const
+        -state observer: SframeStateObserver* const
     }
 
-    SframeActivationObserver <|.. RtpTransceiver
-    RtpSenderBase --> SframeActivationObserver : notifies
-    RtpReceiverBase --> SframeActivationObserver : notifies
+    SframeStateObserver <|.. RtpTransceiver
+    RtpSenderBase --> SframeStateObserver : notifies
+    RtpReceiverBase --> SframeStateObserver : notifies
 ```
 
 **Transceiver state machine:**
 
-| `sframe_activated_` | Meaning | `OnSframeActivated()` result |
+| SFrame enabled state | Meaning | `TryEnableSframe()` result |
 |---|---|---|
-| `std::nullopt` | Not yet decided | Sets to `true`, returns OK |
-| `true` | Already activated | Returns OK (idempotent) |
+| Not yet decided | SFrame has not been enabled or disabled | Sets to enabled, returns OK |
+| Enabled | SFrame is enabled on this transceiver | Returns OK (idempotent) |
+| Disabled | SFrame was explicitly turned off | Returns `INVALID_MODIFICATION` error |
 
-The transceiver's `sframe_activated_` field is used during SDP generation to determine whether `a=sframe` should be included in the corresponding media section. Once set to `true`, it cannot be reverted.
+The transceiver's SFrame enabled state is used during SDP generation to determine whether `a=sframe` should be included in the corresponding media section. Once enabled, it cannot be reverted. The disabled state is set when an offer/answer exchange completes without SFrame — at that point, SFrame can no longer be enabled on this transceiver.
 
 **Constructor injection:** The observer pointer is passed via constructor to `RtpSenderBase` and `RtpReceiverBase`. The transceiver passes `this` when creating sender/receiver instances through the `CreateSender()` and `CreateReceiver()` helper functions.
 
@@ -193,64 +194,28 @@ The transceiver's `sframe_activated_` field is used during SDP generation to det
 sequenceDiagram
     participant App as Application
     participant Sender as RtpSenderBase
-    participant Observer as SframeActivationObserver (Transceiver)
+    participant Observer as SframeStateObserver (Transceiver)
 
     App->>Sender: CreateSframeEncrypterOrError(options)
-    Sender->>Observer: OnSframeActivated()
-    Observer->>Observer: Check sframe_activated_
+    Sender->>Observer: TryEnableSframe()
+    Observer->>Observer: Check SFrame enabled state
 
-    alt sframe_activated_ == nullopt
-        Observer->>Observer: Set sframe_activated_ = true
+    alt SFrame not yet decided
+        Observer->>Observer: Mark SFrame as enabled
+        Observer->>App: Trigger onnegotiationneeded
         Observer-->>Sender: RTCError::OK()
-    else sframe_activated_ == true
-        Observer-->>Sender: RTCError::OK() (already activated)
+    else SFrame already enabled
+        Observer-->>Sender: RTCError::OK() (idempotent)
     end
 
-    Note over Sender: Create internal transformer
-    Note over Sender: Install transformer in pipeline
+    Note over Sender: Create internal encrypter
+    Note over Sender: Install encrypter in send pipeline
     Sender-->>App: RTCErrorOr<SframeEncrypterInterface> handle
 ```
 
-### Transformation Features Hierarchy
+### SframeEncrypterImpl (Internal)
 
-```mermaid
-classDiagram
-    class TransformationFeatures {
-        <<interface>>
-        +UseSFrame() bool
-        #~TransformationFeatures()
-    }
-    
-    class FrameTransformerInterface {
-        <<interface>>
-        +Transform(frame)
-        +RegisterTransformedFrameCallback(callback)
-        +RegisterTransformedFrameSinkCallback(callback, ssrc)
-        +UnregisterTransformedFrameCallback()
-        +UnregisterTransformedFrameSinkCallback(ssrc)
-        #~FrameTransformerInterface()
-    }
-    
-    class PacketTransformerInterface {
-        <<interface>>
-        +Transform(frame)
-        +GetReservedNumberOfBytes() size_t
-        +RegisterTransformedPacketCallback(callback)
-        +RegisterTransformedPacketSinkCallback(callback, ssrc)
-        +UnregisterTransformedPacketCallback()
-        +UnregisterTransformedPacketSinkCallback(ssrc)
-        #~PacketTransformerInterface()
-    }
-    
-    TransformationFeatures <|-- FrameTransformerInterface
-    TransformationFeatures <|-- PacketTransformerInterface
-```
-
-> **Note**: The `GetReservedNumberOfBytes()` method in `PacketTransformerInterface` ensures that the packetizer reserves enough space for SFrame encryption overhead to avoid MTU overflow.
-
-### SFrameSenderTransformer (Internal)
-
-The `SFrameSenderTransformer` is an internal implementation class created by `RtpSenderBase::CreateSframeEncrypterOrError`. It provides SFrame encryption and exposes both the key management interface (returned to the app via proxy) and transformer interfaces (installed in the pipeline).
+The `SframeEncrypterImpl` is the internal implementation of `SframeEncrypterInterface`, created by `RtpSenderBase::CreateSframeEncrypterOrError`. It provides SFrame encryption and exposes the key management interface (returned to the app via proxy). Internally, it is installed in the send pipeline to encrypt frames or packets depending on the configured mode.
 
 ```mermaid
 classDiagram
@@ -259,26 +224,21 @@ classDiagram
         +SetEncryptionKey(key_id, key_material) RTCError
     }
     
-    class SFrameSenderTransformer {
+    class SframeEncrypterImpl {
         -cipher_suite: SframeCipherSuite
         -sframe_mode: SframeMode
-        +SFrameSenderTransformer(init)
+        +SframeEncrypterImpl(init)
         +SetEncryptionKey(key_id, key_material) RTCError
-        +TransformFrame(frame) TransformedFrame
-        +TransformPacket(packet) TransformedPacket
-        +GetReservedNumberOfBytes() size_t
-        +AsFrameTransformer() FrameTransformerInterface*
-        +AsPacketTransformer() PacketTransformerInterface*
+        +EncryptFrame(frame) EncryptedFrame
+        +EncryptPacket(packet) EncryptedPacket
     }
     
-    SframeEncrypterInterface <|-- SFrameSenderTransformer
+    SframeEncrypterInterface <|-- SframeEncrypterImpl
 ```
 
-> **Diamond Inheritance**: `SFrameSenderTransformer` cannot directly implement both `FrameTransformerInterface` and `PacketTransformerInterface` due to diamond inheritance from the common `TransformationFeatures` base. The factory methods `AsFrameTransformer()` and `AsPacketTransformer()` return separate wrapper objects that implement the respective interfaces and delegate to the transformer.
+### SframeDecrypterImpl (Internal)
 
-### SFrameReceiverTransformer (Internal)
-
-The `SFrameReceiverTransformer` is created by `RtpReceiverBase::CreateSframeDecrypterOrError`. It provides SFrame decryption with the same factory pattern for transformer interfaces.
+The `SframeDecrypterImpl` is the internal implementation of `SframeDecrypterInterface`, created by `RtpReceiverBase::CreateSframeDecrypterOrError`. It provides SFrame decryption and exposes the key management interface (returned to the app via proxy). Internally, it is installed in the receive pipeline to decrypt frames or packets.
 
 ```mermaid
 classDiagram
@@ -288,58 +248,50 @@ classDiagram
         +RemoveDecryptionKey(key_id) RTCError
     }
     
-    class SFrameReceiverTransformer {
+    class SframeDecrypterImpl {
         -cipher_suite: SframeCipherSuite
-        +SFrameReceiverTransformer(init)
+        +SframeDecrypterImpl(init)
         +AddDecryptionKey(key_id, key_material) RTCError
         +RemoveDecryptionKey(key_id) RTCError
-        +TransformFrame(frame) TransformedFrame
-        +TransformPacket(packet) TransformedPacket
-        +GetReservedNumberOfBytes() size_t
-        +AsFrameTransformer() FrameTransformerInterface*
-        +AsPacketTransformer() PacketTransformerInterface*
+        +DecryptFrame(frame) DecryptedFrame
+        +DecryptPacket(packet) DecryptedPacket
     }
     
-    SframeDecrypterInterface <|-- SFrameReceiverTransformer
+    SframeDecrypterInterface <|-- SframeDecrypterImpl
 ```
 
 ### CreateSframeEncrypterOrError Internal Flow
 
 When the application calls `CreateSframeEncrypterOrError`, the sender:
 1. Notifies the transceiver via the observer
-2. Creates the internal `SFrameSenderTransformer`
-3. Based on mode, gets the appropriate transformer wrapper and installs it in the pipeline
-4. Wraps the transformer in a thread-safe proxy
+2. Creates the internal `SframeEncrypterImpl`
+3. Installs the encrypter in the send pipeline
+4. Wraps the encrypter in a thread-safe proxy
 5. Returns the proxy as the key management handle
 
 ```mermaid
 sequenceDiagram
     participant App as Application
     participant Sender as RtpSenderBase
-    participant Observer as SframeActivationObserver
-    participant Transformer as SFrameSenderTransformer
+    participant Observer as SframeStateObserver
+    participant Encrypter as SframeEncrypterImpl
     participant Proxy as SframeEncrypterProxy
     participant Pipeline as Send Pipeline
 
     App->>Sender: CreateSframeEncrypterOrError(options)
 
-    Sender->>Observer: OnSframeActivated()
+    Sender->>Observer: TryEnableSframe()
+    Note over Observer: Mark SFrame as enabled
+    Observer->>App: Trigger onnegotiationneeded
     Observer-->>Sender: RTCError::OK()
 
-    Sender->>Transformer: Create SFrameSenderTransformer(options)
-    Transformer-->>Sender: transformer instance
+    Sender->>Encrypter: Create SframeEncrypterImpl(options)
+    Encrypter-->>Sender: encrypter instance
 
-    alt options.mode == kPerFrame
-        Sender->>Transformer: AsFrameTransformer()
-        Transformer-->>Sender: FrameTransformerInterface*
-        Sender->>Pipeline: SetFrameTransformer(wrapper)
-    else options.mode == kPerPacket
-        Sender->>Transformer: AsPacketTransformer()
-        Transformer-->>Sender: PacketTransformerInterface*
-        Sender->>Pipeline: SetPacketTransformer(wrapper)
-    end
+    Sender->>Pipeline: Install SFrame encrypter
+    Note over Pipeline: Encrypter installed for encryption
 
-    Sender->>Proxy: Wrap transformer as SframeEncrypterProxy
+    Sender->>Proxy: Wrap encrypter as SframeEncrypterProxy
     Note over Proxy: Thread-safe wrapper for key management
 
     Sender-->>App: RTCErrorOr<scoped_refptr<SframeEncrypterInterface>>(proxy)
@@ -351,23 +303,25 @@ sequenceDiagram
 sequenceDiagram
     participant App as Application
     participant Receiver as RtpReceiverBase
-    participant Observer as SframeActivationObserver
-    participant Transformer as SFrameReceiverTransformer
+    participant Observer as SframeStateObserver
+    participant Decrypter as SframeDecrypterImpl
     participant Proxy as SframeDecrypterProxy
     participant Pipeline as Receive Pipeline
 
     App->>Receiver: CreateSframeDecrypterOrError(options)
 
-    Receiver->>Observer: OnSframeActivated()
+    Receiver->>Observer: TryEnableSframe()
+    Note over Observer: Mark SFrame as enabled
+    Observer->>App: Trigger onnegotiationneeded
     Observer-->>Receiver: RTCError::OK()
 
-    Receiver->>Transformer: Create SFrameReceiverTransformer(options)
-    Transformer-->>Receiver: transformer instance
+    Receiver->>Decrypter: Create SframeDecrypterImpl(options)
+    Decrypter-->>Receiver: decrypter instance
 
-    Note over Receiver: Install appropriate transformer in pipeline
-    Receiver->>Pipeline: SetFrameTransformer() or SetPacketTransformer()
+    Receiver->>Pipeline: Install SFrame decrypter
+    Note over Pipeline: Decrypter installed for decryption
 
-    Receiver->>Proxy: Wrap transformer as SframeDecrypterProxy
+    Receiver->>Proxy: Wrap decrypter as SframeDecrypterProxy
     Note over Proxy: Thread-safe wrapper for key management
 
     Receiver-->>App: RTCErrorOr<scoped_refptr<SframeDecrypterInterface>>(proxy)
@@ -379,10 +333,10 @@ sequenceDiagram
 
 Key management calls on the returned `SframeEncrypterInterface` and `SframeDecrypterInterface` handles are thread-safe. The proxy pattern ensures all calls are marshaled to the worker thread:
 
-- **SframeEncrypterProxy**: Wraps `SFrameSenderTransformer`, marshals `SetEncryptionKey` to worker thread
-- **SframeDecrypterProxy**: Wraps `SFrameReceiverTransformer`, marshals `AddDecryptionKey`/`RemoveDecryptionKey` to worker thread
+- **SframeEncrypterProxy**: Wraps `SframeEncrypterImpl`, marshals `SetEncryptionKey` to worker thread
+- **SframeDecrypterProxy**: Wraps `SframeDecrypterImpl`, marshals `AddDecryptionKey`/`RemoveDecryptionKey` to worker thread
 
-The transformer itself always runs on the worker thread, ensuring single-threaded access to encryption/decryption state.
+The encrypter/decrypter itself always runs on the worker thread, ensuring single-threaded access to encryption/decryption state.
 
 ### Sender Key Management Flow
 
@@ -390,21 +344,21 @@ The transformer itself always runs on the worker thread, ensuring single-threade
 sequenceDiagram
     participant App as Application
     participant Proxy as SframeEncrypterProxy (returned handle)
-    participant Transformer as SFrameSenderTransformer
+    participant Encrypter as SframeEncrypterImpl
 
     App->>Proxy: SetEncryptionKey(key_id, key_material)
     
     Note over Proxy: Calling Thread - Post task to worker thread
     Proxy->>Proxy: PostTask to Worker Thread
     
-    Note over Transformer: Worker Thread - Execute key update
-    Proxy->>+Transformer: SetEncryptionKey(key_id, key_material)
-    Transformer-->>-Proxy: RTCError::OK()
+    Note over Encrypter: Worker Thread - Execute key update
+    Proxy->>+Encrypter: SetEncryptionKey(key_id, key_material)
+    Encrypter-->>-Proxy: RTCError::OK()
     
     Note over Proxy: Calling Thread - Return result
     Proxy-->>App: RTCError::OK()
     
-    Note over App,Transformer: ✓ Key is now active for encryption
+    Note over App,Encrypter: ✓ Key is now set for encryption
 ```
 
 ### Receiver Key Management Flow
@@ -413,21 +367,21 @@ sequenceDiagram
 sequenceDiagram
     participant App as Application
     participant Proxy as SframeDecrypterProxy (returned handle)
-    participant Transformer as SFrameReceiverTransformer
+    participant Decrypter as SframeDecrypterImpl
 
     App->>Proxy: AddDecryptionKey(key_id, key_material)
     
     Note over Proxy: Calling Thread - Post task to worker thread
     Proxy->>Proxy: PostTask to Worker Thread
     
-    Note over Transformer: Worker Thread - Execute add key
-    Proxy->>+Transformer: AddDecryptionKey(key_id, key_material)
-    Transformer-->>-Proxy: RTCError::OK()
+    Note over Decrypter: Worker Thread - Execute add key
+    Proxy->>+Decrypter: AddDecryptionKey(key_id, key_material)
+    Decrypter-->>-Proxy: RTCError::OK()
     
     Note over Proxy: Calling Thread - Return result
     Proxy-->>App: RTCError::OK()
     
-    Note over App,Transformer: ✓ New key available for decryption
+    Note over App,Decrypter: ✓ New key available for decryption
     
     Note over App: Later, during key rotation...
     
@@ -436,214 +390,51 @@ sequenceDiagram
     Note over Proxy: Calling Thread - Post task to worker thread
     Proxy->>Proxy: PostTask to Worker Thread
     
-    Note over Transformer: Worker Thread - Execute remove key
-    Proxy->>+Transformer: RemoveDecryptionKey(old_key_id)
-    Transformer-->>-Proxy: RTCError::OK()
+    Note over Decrypter: Worker Thread - Execute remove key
+    Proxy->>+Decrypter: RemoveDecryptionKey(old_key_id)
+    Decrypter-->>-Proxy: RTCError::OK()
     
     Proxy-->>App: RTCError::OK()
     
-    Note over App,Transformer: ✓ Old key removed, only new key remains
-```
-
-## Transformer Installation Flows
-
-These flows show how transformers propagate through the internal layers. In the new API, the sender/receiver calls these internally during `CreateSframeEncrypterOrError` / `CreateSframeDecrypterOrError` — the application does not call `SetFrameTransformer` / `SetPacketTransformer` directly for SFrame.
-
-### RtpSender FrameTransformer Installation Flow
-
-```mermaid
-sequenceDiagram
-    participant App as Application
-    participant Sender as RtpSenderBase
-    participant Passthrough as Internal Layers (Passthrough)
-    participant VideoSender as RTPSenderVideo
-
-    App->>Sender: SetFrameTransformer(transformer)
-    
-    Note over Sender,VideoSender: Propagation through internal layers
-    
-    Sender->>Passthrough: SetFrameTransformer(transformer)
-    Passthrough->>VideoSender: SetFrameTransformer(transformer)
-    
-    Note over VideoSender: Install transformer to FrameTransformerDelegate
-
-    VideoSender-->>Passthrough: return success
-    Passthrough-->>Sender: return success
-    Sender-->>App: return success
-    
-    Note over VideoSender : Frame transformer is now active in media pipeline
-```
-
-### RtpSender PacketTransformer Installation Flow
-
-```mermaid
-sequenceDiagram
-    participant App as Application
-    participant Sender as RtpSenderBase
-    participant Passthrough as Internal Layers (Passthrough)
-    participant VideoSender as RTPSenderVideo
-
-    App->>Sender: SetPacketTransformer(transformer)
-    
-    Note over Sender,VideoSender: Propagation through internal layers
-    
-    Sender->>Passthrough: SetPacketTransformer(transformer)
-    Passthrough->>VideoSender: SetPacketTransformer(transformer)
-    
-    Note over VideoSender: Install transformer in PacketTransformerDelegate
-    
-    VideoSender-->>Passthrough: return success
-    Passthrough-->>Sender: return success
-    Sender-->>App: return success
-    
-    Note over VideoSender: Packet transformer now active in media pipeline
-```
-
-### RtpReceiver(Video) FrameTransformer Installation Flow
-
-```mermaid
-sequenceDiagram
-    participant App as Application
-    participant Receiver as VideoRtpReceiver
-    participant Passthrough as Internal Layers (Passthrough)
-    participant StreamReceiver as RtpVideoStreamReceiver2
-    participant Delegate as RtpVideoStreamReceiverFrameTransformerDelegate
-
-    App->>Receiver: SetFrameTransformer(transformer)
-    
-    Note over Receiver,Delegate: Propagation through receiver stack
-    
-    Receiver->>Passthrough: SetFrameTransformer(transformer)
-    Passthrough->>StreamReceiver: SetFrameTransformer(transformer)
-    
-    Note over StreamReceiver,Delegate: Install transformer to delegate
-    
-    StreamReceiver->>Delegate: SetFrameTransformer(transformer)
-    
-    Note over Delegate: Frame transformer installed and active
-    
-    Delegate-->>StreamReceiver: return success
-    StreamReceiver-->>Passthrough: return success
-    Passthrough-->>Receiver: return success
-    Receiver-->>App: return success
-    
-    Note over Delegate : Frame transformer is now active for decryption
-```
-
-### RtpReceiver(Video) PacketTransformer Installation Flow
-
-```mermaid
-sequenceDiagram
-    participant App as Application
-    participant Receiver as VideoRtpReceiver
-    participant Passthrough as Internal Layers (Passthrough)
-    participant StreamReceiver as RtpVideoStreamReceiver2
-
-    App->>Receiver: SetPacketTransformer(transformer)
-    
-    Note over Receiver,StreamReceiver: Propagation through receiver stack
-    
-    Receiver->>Passthrough: SetPacketTransformer(transformer)
-    Passthrough->>StreamReceiver: SetPacketTransformer(transformer)
-    
-    Note over StreamReceiver: Install transformer in PacketTransformerDelegate
-    
-    StreamReceiver-->>Passthrough: return success
-    Passthrough-->>Receiver: return success
-    Receiver-->>App: return success
-    
-    Note over StreamReceiver: Packet transformer now active for decryption
-```
-
-### RtpReceiver(Audio) FrameTransformer Installation Flow
-
-```mermaid
-sequenceDiagram
-    participant App as Application
-    participant Receiver as AudioRtpReceiver
-    participant Passthrough as Internal Layers (Passthrough)
-    participant ChannelReceive as ChannelReceive
-
-    App->>Receiver: SetFrameTransformer(transformer)
-    
-    Note over Receiver,ChannelReceive: Propagation through receiver stack
-    
-    Receiver->>Passthrough: SetFrameTransformer(transformer)
-    Passthrough->>ChannelReceive: SetDepacketizerToDecoderFrameTransformer(transformer)
-    
-    Note over ChannelReceive: Install transformer for frame processing
-    
-    ChannelReceive-->>Passthrough: return success
-    Passthrough-->>Receiver: return success
-    Receiver-->>App: return success
-    
-    Note over ChannelReceive: Frame transformer now active for audio decryption
-```
-
-### RtpReceiver(Audio) PacketTransformer Installation Flow
-
-```mermaid
-sequenceDiagram
-    participant App as Application
-    participant Receiver as AudioRtpReceiver
-    participant Passthrough as Internal Layers (Passthrough)
-    participant ChannelReceive as ChannelReceive
-
-    App->>Receiver: SetPacketTransformer(transformer)
-    
-    Note over Receiver,ChannelReceive: Propagation through receiver stack
-    
-    Receiver->>Passthrough: SetPacketTransformer(transformer)
-    Passthrough->>ChannelReceive: SetPacketTransformer(transformer)
-    
-    Note over ChannelReceive: Install transformer for packet processing
-    
-    ChannelReceive-->>Passthrough: return success
-    Passthrough-->>Receiver: return success
-    Receiver-->>App: return success
-    
-    Note over ChannelReceive: Packet transformer now active for audio decryption
+    Note over App,Decrypter: ✓ Old key removed, only new key remains
 ```
 
 ## Media Processing Flows
 
 ### RtpSender Frame Processing Flow - Video
 
-This flow describes how encoded video frames are processed through the RTP sender pipeline with SFrame encryption support. The pipeline handles both frame-level and packet-level encryption modes, with appropriate transformers applied at each stage.
+This flow describes how encoded video frames are processed through the RTP sender pipeline with SFrame encryption support. The pipeline handles both frame-level and packet-level encryption modes, with the `SframeEncrypterImpl` invoked directly at the appropriate stage.
 
 **Flow Overview:**
 
 1. **Frame Reception**: The video encoder produces an encoded frame and forwards it to the RTP sender for transmission.
 
 2. **SFrame Configuration Validation**: The sender validates the SFrame configuration:
-   - If SFrame is enabled, it checks whether the appropriate transformer (frame or packet) is available
-   - If SFrame is enabled but no sframe transformer is available, the frame is dropped
-   - If SFrame is not enabled, processing continues normally without SFrame encryption
+   - If SFrame is enabled, it checks whether the `SframeEncrypterImpl` has been installed and has a key set
+   - If SFrame is enabled but the encrypter is not ready, the frame is dropped
+   - If SFrame is not enabled, processing continues normally without encryption
 
-3. **Frame Transformation**: When a frame transformer exists, the encoded frame is forwarded to it:
-   - The frame transformer applies transformation to the frame payload
-   - This occurs before packetization, transforming the complete frame
-   - If no frame transformer exists, this step is skipped
+3. **Frame Encryption** (per-frame mode only): When SFrame per-frame mode is enabled, the `SframeEncrypterImpl` encrypts the complete encoded frame before packetization:
+   - The frame payload is encrypted and the SFrame header is prepended
+   - If SFrame is not enabled or per-packet mode is enabled, this step is skipped
 
-4. **Packetization**: The sender determines the appropriate packetizer based on the frame transformer's `UseSFrame()` method:
-   - If `UseSFrame()` returns true, an SFrame-aware packetizer is used that adds SFrame-specific headers to RTP packets
-   - If `UseSFrame()` returns false (or no frame transformer), a codec-specific packetizer is used for standard RTP packet creation
+4. **Packetization**: The sender determines the appropriate packetizer based on the enabled SFrame mode:
+   - If SFrame per-frame mode is enabled, an SFrame-aware packetizer is used that creates RTP packets with SFrame-specific headers (the frame payload is already encrypted at this point)
+   - If SFrame per-packet mode is enabled or SFrame is not enabled, a codec-specific packetizer is used for standard RTP packet creation
 
-5. **Packet Transformation**: When a packet transformer exists, each RTP packet is individually processed:
-   - Each packet is forwarded to the packet transformer
-   - The transformer applies packet-level transformations
-   - This occurs after packetization, transforming individual packets
-   - If no packet transformer exists, this step is skipped
+5. **Packet Encryption** (per-packet mode only): When SFrame per-packet mode is enabled, the `SframeEncrypterImpl` encrypts each RTP packet individually:
+   - Each packet payload is encrypted and the SFrame header is prepended
+   - This occurs after packetization, encrypting individual packets
+   - If SFrame is not enabled or per-frame mode is enabled, this step is skipped
 
-6. **Repacketization** (when packet transformer with SFrame is used): Additional SFrame-specific headers may be inserted into packets.
+6. **Repacketization** (per-packet mode only): SFrame-specific RTP headers are inserted into the encrypted packets.
 
 ```mermaid
 sequenceDiagram
     participant Encoder as Video Encoder
     participant Sender as RtpSender
-    participant FrameTransformer as Frame Transformer
+    participant Encrypter as SframeEncrypterImpl
     participant Packetizer as Packetizer
-    participant PacketTransformer as Packet Transformer
     participant Network as Network
 
     Encoder->>Sender: 1. EncodedFrame received
@@ -651,100 +442,99 @@ sequenceDiagram
     Note over Sender: STEP 2: Validate SFrame Configuration
 
     alt SFrame Enabled
-        Sender->>Sender: Check transformer availability
-        alt No SFrame Transformer Available
+        Sender->>Sender: Check encrypter availability and key status
+        alt Encrypter not ready
             Sender-->>Encoder: ❌ return (drop frame)
         end
     else SFrame Not Enabled
         Note over Sender: Continue normal processing
     end
     
-    Note over Sender,FrameTransformer: STEP 3: Frame Transformation
+    Note over Sender,Encrypter: STEP 3: Frame Encryption (per-frame mode)
     
-    Sender->>FrameTransformer: Forward frame
-    FrameTransformer->>FrameTransformer: Transform frame
-    FrameTransformer-->>Sender: Transformed frame
+    alt SFrame per-frame mode enabled
+        Sender->>Encrypter: EncryptFrame(frame)
+        Encrypter->>Encrypter: Encrypt payload, prepend SFrame header
+        Encrypter-->>Sender: Encrypted frame
+    else
+        Note over Sender: Skip frame encryption
+    end
     
     Note over Sender,Packetizer: STEP 4: Packetization
     
-    Sender->>FrameTransformer: Call UseSFrame()
-    FrameTransformer-->>Sender: returns if SFrame transformer or not
+    Sender->>Sender: Check SFrame mode
     
-    alt FrameTransformer->UseSFrame() == true
+    alt SFrame per-frame mode enabled
         Note over Sender,Packetizer: Use SFrame-aware packetizer
         
         Sender->>Packetizer: Packetize with SFrame Packetizer
         Packetizer-->>Sender: SFrame RTP packets
-    else FrameTransformer->UseSFrame() == false
+    else SFrame per-packet mode or no SFrame
         Note over Sender,Packetizer: Use codec specific packetizer
         
         Sender->>Packetizer: Codec Specific packetization
         Packetizer-->>Sender: Codec specific RTP packets
     end
     
-    Note over Sender,PacketTransformer: STEP 5: Packet Transformation
+    Note over Sender,Encrypter: STEP 5: Packet Encryption (per-packet mode)
     
-    alt PacketTransformer exists
+    alt SFrame per-packet mode enabled
         loop Each RTP Packet
-            Sender->>PacketTransformer: Forward packet
-            PacketTransformer->>PacketTransformer: Transform packet
-            PacketTransformer-->>Sender: Transformed packet
+            Sender->>Encrypter: EncryptPacket(packet)
+            Encrypter->>Encrypter: Encrypt payload, prepend SFrame header
+            Encrypter-->>Sender: Encrypted packet
         end
 
-        loop
-            Note over Sender: STEP 6: Repacketization
-            alt PacketTransformer->UseSFrame() == true
-                Sender->>Sender: Insert SFrame headers to 
-            end
+        Note over Sender: STEP 6: Repacketization
+        loop Each Encrypted Packet
+            Sender->>Sender: Insert SFrame-specific RTP headers
         end
         
     else
-        Note over Sender: Skip packet transformation
+        Note over Sender: Skip packet encryption
     end
     
     Note over Sender,Network: STEP 7: Network Transmission
-    Sender->>Network: Send encrypted packets
+    Sender->>Network: Send packets
     
     Note over Encoder,Network: ✓ Processing complete - Frame encrypted and sent
 ```
 
 ### RtpReceiver Frame Processing Flow - Video
 
-This flow describes how received RTP packets are processed through the video receiver pipeline with SFrame decryption support. The pipeline handles both packet-level and frame-level decryption modes, reconstructing and decrypting video frames before forwarding them to the decoder.
+This flow describes how received RTP packets are processed through the video receiver pipeline with SFrame decryption support. The pipeline handles both packet-level and frame-level decryption modes, with the `SframeDecrypterImpl` invoked directly at the appropriate stage.
 
 **Flow Overview:**
 
 1. **Packet Reception**: RTP packets arrive from the network transport and are received by the VideoRtpReceiver.
 
 2. **SFrame Configuration Validation**: The receiver validates the SFrame configuration:
-   - If SFrame is enabled, it checks whether the appropriate sframe transformer (packet or frame) is available
-   - If SFrame is enabled but no sframe transformer is available, the packets are dropped
+   - If SFrame is enabled, it checks whether the `SframeDecrypterImpl` has been installed and has keys available
+   - If SFrame is enabled but the decrypter is not ready, the packets are dropped
    - If SFrame is not enabled, processing continues normally without decryption
 
-3. **Pre-repacketization**: When a packet transformer exists, and it implements SFrame (packet_transformer->UseSFrame() return true), it should remove SFrame headers from packets before pushing it to the packet transformer
+3. **SFrame Header Removal** (per-packet mode only): When SFrame per-packet mode is enabled, SFrame-specific RTP headers are stripped from each packet before decryption.
 
-4. **Packet Transformation**: When a packet transformer exists, each received RTP packet is individually processed:
-   - Each packet is forwarded to the packet transformer for transformation
-   - The transformer removes SFrame headers and decrypts the packet payload
+4. **Packet Decryption** (per-packet mode only): When SFrame per-packet mode is enabled, the `SframeDecrypterImpl` decrypts each RTP packet individually:
+   - The SFrame header is parsed and the packet payload is decrypted
    - This occurs before depacketization, working on individual encrypted packets
-   - If no packet transformer exists, this step is skipped
+   - If SFrame is not enabled or per-frame mode is enabled, this step is skipped
 
-5. **Depacketization**: The receiver determines the appropriate depacketizer based on the packet transformer's `UseSFrame()` method:
-   - If `UseSFrame()` returns true, an SFrame depacketizer is used to reconstruct the encrypted frame from SFrame-formatted packets
-   - If `UseSFrame()` returns false (or no packet transformer), a codec-specific depacketizer reconstructs the frame using standard media depacketization
+5. **Depacketization**: The receiver determines the appropriate depacketizer based on the enabled SFrame mode:
+   - If SFrame per-frame mode is enabled, an SFrame depacketizer is used to reconstruct the encrypted frame from SFrame-formatted packets
+   - If SFrame per-packet mode is enabled or SFrame is not enabled, a codec-specific depacketizer reconstructs the frame using standard media depacketization
    - The depacketizer assembles RTP packets into complete video frames
 
-6. **Frame Transformation**: When a frame transformer exists, the assembled frame is processed:
-   - The frame is forwarded to the frame transformer for decryption
-   - The transformer decrypts the complete frame payload
+6. **Frame Decryption** (per-frame mode only): When SFrame per-frame mode is enabled, the `SframeDecrypterImpl` decrypts the complete assembled frame:
+   - The SFrame header is parsed and the frame payload is decrypted
    - This occurs after depacketization, working on the reassembled encrypted frame
-   - If no frame transformer exists, this step is skipped
+   - If SFrame is not enabled or per-packet mode is enabled, this step is skipped
 
 7. **Decoding**: The processed (and potentially decrypted) frame is forwarded to the video decoder for final decoding into displayable video.
 
 The flow supports three operational modes:
-- **Frame Mode**: SFrame depacketizer reconstructs encrypted frame, frame transformer decrypts the complete frame
-- **Packet Mode**: Packet transformer decrypts individual packets, standard depacketizer reconstructs the frame
+- **Per-frame mode**: SFrame depacketizer reconstructs encrypted frame, `SframeDecrypterImpl` decrypts the complete frame
+- **Per-packet mode**: `SframeDecrypterImpl` decrypts individual packets, standard depacketizer reconstructs the frame
 - **No SFrame**: Standard RTP packet reception, depacketization, and decoding without decryption
 
 This receiver flow is the inverse of the sender flow, ensuring that encrypted frames can be properly reconstructed and decrypted regardless of whether frame-level or packet-level encryption was used.
@@ -753,9 +543,8 @@ This receiver flow is the inverse of the sender flow, ensuring that encrypted fr
 sequenceDiagram
     participant Network as Network Transport
     participant Receiver as VideoRtpReceiver
-    participant PacketTransformer as Packet Transformer
+    participant Decrypter as SframeDecrypterImpl
     participant Depacketizer as Depacketizer
-    participant FrameTransformer as Frame Transformer
     participant Decoder as Video Decoder
 
     Network->>Receiver: 1. Receive RTP Packets
@@ -763,64 +552,56 @@ sequenceDiagram
     Note over Receiver: STEP 2: Validate SFrame Configuration
 
     alt SFrame Enabled
-        Receiver->>Receiver: Check transformer availability
-        alt No SFrame Transformer Available
+        Receiver->>Receiver: Check decrypter availability and key status
+        alt Decrypter not ready
             Receiver-->>Network: ❌ return (drop packets)
         end
     else SFrame Not Enabled
         Note over Receiver: Continue normal processing
     end
     
-    Note over Receiver,PacketTransformer: STEP 3: Pre-Transformation SFrame Header Removal
+    Note over Receiver,Decrypter: STEP 3: SFrame Header Removal (per-packet mode)
     
-    alt PacketTransformer exists
-        Receiver->>PacketTransformer: Call UseSFrame()
-        PacketTransformer-->>Receiver: returns if SFrame transformer or not
-        
-        alt PacketTransformer->UseSFrame() == true
-            loop Each RTP Packet
-                Receiver->>Receiver: Remove SFrame headers from packet
-            end
+    alt SFrame per-packet mode enabled
+        loop Each RTP Packet
+            Receiver->>Receiver: Remove SFrame-specific RTP headers
         end
     end
     
-    Note over Receiver,PacketTransformer: STEP 4: Packet Transformation
+    Note over Receiver,Decrypter: STEP 4: Packet Decryption (per-packet mode)
     
-    alt PacketTransformer exists
+    alt SFrame per-packet mode enabled
         loop Each RTP Packet
-            Receiver->>PacketTransformer: Forward packet
-            PacketTransformer->>PacketTransformer: Transform packet
-            PacketTransformer-->>Receiver: Transformed packet
+            Receiver->>Decrypter: DecryptPacket(packet)
+            Decrypter->>Decrypter: Parse SFrame header, decrypt payload
+            Decrypter-->>Receiver: Decrypted packet
         end
     else
-        Note over Receiver: Skip packet transformation
+        Note over Receiver: Skip packet decryption
     end
     
     Note over Receiver,Depacketizer: STEP 5: Depacketization
     
-    Receiver->>PacketTransformer: Call UseSFrame()
-    PacketTransformer-->>Receiver: returns if SFrame transformer or not
-    
-    alt PacketTransformer->UseSFrame() == true
+    alt SFrame per-frame mode enabled
         Note over Receiver,Depacketizer: Use SFrame depacketizer
         
         Receiver->>Depacketizer: Depacketize with SFrame Depacketizer
         Depacketizer-->>Receiver: Assembled SFrame encrypted frame
-    else PacketTransformer->UseSFrame() == false
+    else SFrame per-packet mode or no SFrame
         Note over Receiver,Depacketizer: Use codec specific depacketizer
         
         Receiver->>Depacketizer: Codec Specific depacketization
         Depacketizer-->>Receiver: Assembled codec specific frame
     end
     
-    Note over Receiver,FrameTransformer: STEP 6: Frame Transformation
+    Note over Receiver,Decrypter: STEP 6: Frame Decryption (per-frame mode)
     
-    alt FrameTransformer exists
-        Receiver->>FrameTransformer: Forward frame
-        FrameTransformer->>FrameTransformer: Transform frame
-        FrameTransformer-->>Receiver: Transformed frame
+    alt SFrame per-frame mode enabled
+        Receiver->>Decrypter: DecryptFrame(frame)
+        Decrypter->>Decrypter: Parse SFrame header, decrypt payload
+        Decrypter-->>Receiver: Decrypted frame
     else
-        Note over Receiver: Skip frame transformation
+        Note over Receiver: Skip frame decryption
     end
     
     Note over Receiver,Decoder: STEP 7: Decoding

--- a/README.md
+++ b/README.md
@@ -1,82 +1,214 @@
 # WebRTC SFrame Integration Architecture
 
-This document describes the architectural design for integrating SFrame (Secure Frame) encryption into WebRTC applications. SFrame provides end-to-end media security that works even when media flows through untrusted servers or intermediaries.
+This document describes the architectural design for integrating SFrame (Secure Frame) encryption into WebRTC's native C++ API. SFrame provides end-to-end media security as defined by [RFC 9605](https://www.rfc-editor.org/rfc/rfc9605.html) and [draft-ietf-avtcore-rtp-sframe](https://github.com/ietf-wg-avtcore/draft-ietf-avtcore-rtp-sframe).
 
 ## Overview
 
-SFrame encryption can be applied at two different levels:
-- **Per-frame**: Encrypts complete video/audio frames before packetization
-- **Per-packet**: Encrypts individual RTP packets after packetization
+SFrame encryption can be applied at two levels:
+- **Per-frame** (`SframeMode::kPerFrame`): Encrypts complete video/audio frames before packetization
+- **Per-packet** (`SframeMode::kPerPacket`): Encrypts individual RTP packets after packetization
 
-Both approaches offer strong security guarantees, with per-packet providing finer granularity and per-frame offering better performance characteristics.
+Both modes are activated through the same public API on `RtpSenderInterface` and `RtpReceiverInterface`. The application creates an SFrame encrypter or decrypter by calling a method on the sender or receiver, receives a key management handle, and the internal pipeline handles transformer installation and SDP negotiation automatically.
 
 ## Architecture Overview
 
 ```mermaid
 sequenceDiagram
-    participant App as WebRTC Application
-    participant T as RTP Transceiver
-    participant SenderTransform as SFrameSenderTransform
-    participant ReceiverTransform as SFrameReceiverTransform
-    participant S as RTP Sender
-    participant R as RTP Receiver
+    participant App as Application
+    participant T as RtpTransceiver
+    participant S as RtpSender
+    participant R as RtpReceiver
+    participant EncHandle as SframeEncrypterInterface
+    participant DecHandle as SframeDecrypterInterface
 
-    Note over App,R: SFrame Enablement and Setup Flow
+    Note over App,DecHandle: SFrame Activation Flow
 
-    App->>T: 1. SetUseSFrame(true)
-    
-    Note over T: STEP 2: Propagate SFrame enablement to RTP interfaces
-    T->>S: Enable SFrame encryption
-    S-->>T: SFrame enabled on sender
-    T->>R: Enable SFrame decryption
-    R-->>T: SFrame enabled on receiver
-    T-->>App: return success
-    
-    Note over T: STEP 3: Triggers negotiation needed
-    T->>App: on negotiation needed event
-    
-    Note over App,SenderTransform: STEP 4: Application handles sender setup
-    App->>SenderTransform: Create SFrameSenderTransform(options, sender, thread)
-    
-    alt sframe_mode == kFrame
-        SenderTransform->>S: SetFrameTransformer(SFrameSenderTransformer.AsFrameTransformer())
-        S-->>SenderTransform: Frame transformer assigned
-    else sframe_mode == kPacket
-        SenderTransform->>S: SetPacketTransformer(SFrameSenderTransformer.AsPacketTransformer())
-        S-->>SenderTransform: Packet transformer assigned
-    end
-    
-    SenderTransform-->>App: Sender transform configured
-    
-    Note over App,ReceiverTransform: STEP 5: Application handles receiver setup
-    App->>ReceiverTransform: Create SFrameReceiverTransform(options, receiver, thread)
-    
-    alt sframe_mode == kFrame
-        ReceiverTransform->>R: SetFrameTransformer(SFrameReceiverFrameTransformer)
-        R-->>ReceiverTransform: Frame transformer assigned
-    else sframe_mode == kPacket
-        ReceiverTransform->>R: SetPacketTransformer(SFrameReceiverPacketTransformer)
-        R-->>ReceiverTransform: Packet transformer assigned
-    end
-    
-    ReceiverTransform-->>App: Receiver transform configured
-    
-    Note over App,R: ✓ SFrame encryption/decryption now active in media pipeline
+    App->>S: CreateSframeEncrypterOrError(options)
+    Note over S: Creates internal SFrame transformer<br/>Installs transformer in send pipeline
+    S->>T: OnSframeActivated() via observer
+    Note over T: Sets sframe_activated_ = true
+    S-->>App: RTCErrorOr<SframeEncrypterInterface>
+    App->>EncHandle: Store key management handle
+
+    App->>R: CreateSframeDecrypterOrError(options)
+    Note over R: Creates internal SFrame transformer<br/>Installs transformer in receive pipeline
+    R->>T: OnSframeActivated() via observer
+    Note over T: Already activated, returns OK
+    R-->>App: RTCErrorOr<SframeDecrypterInterface>
+    App->>DecHandle: Store key management handle
+
+    Note over T: Triggers onnegotiationneeded
+    T->>App: onnegotiationneeded event
+
+    Note over App: Offer/answer exchange includes a=sframe
+
+    Note over App,DecHandle: Key Management
+
+    App->>EncHandle: SetEncryptionKey(key_id, key_material)
+    Note over EncHandle: Encryption key set on worker thread
+
+    App->>DecHandle: AddDecryptionKey(key_id, key_material)
+    Note over DecHandle: Decryption key added on worker thread
+
+    Note over App,DecHandle: ✓ SFrame encryption/decryption active in media pipeline
 ```
 
-## Core Interface Architecture
+## Public API
 
-### RtpTransceiverInterface
+### SFrame Types (`api/sframe/sframe_types.h`)
 
-Extend `RtpTransceiverInterface` to enable setting `SFrame` configuration which will trigger `on negotiation needed` event.
+```cpp
+enum class SframeMode {
+  kPerFrame,
+  kPerPacket,
+};
+
+enum class SframeCipherSuite {
+  kAesCtr128HmacSha256_80,
+  kAesCtr128HmacSha256_64,
+  kAesCtr128HmacSha256_32,
+  kAesGcm128,
+  kAesGcm256,
+};
+```
+
+### SFrame Encrypter Configuration and Interface (`api/sframe/sframe_encrypter_interface.h`)
 
 ```mermaid
 classDiagram
-  class RtpTransceiverInterface {
-    <<interface>>
-    +SetUseSFrame(bool)
-    +UseSFrame() bool
-  }
+    class SframeEncrypterInit {
+        +mode: SframeMode
+        +cipher_suite: SframeCipherSuite
+    }
+
+    class SframeEncrypterInterface {
+        <<interface>>
+        +SetEncryptionKey(key_id: uint64_t, key_material: ArrayView~const uint8_t~) RTCError
+    }
+
+    SframeEncrypterInit --> SframeMode
+    SframeEncrypterInit --> SframeCipherSuite
+    RefCountInterface <|-- SframeEncrypterInterface
+```
+
+The encrypter init carries both `mode` (per-frame or per-packet) and `cipher_suite`. The mode determines which internal transformer is created and how the send pipeline processes frames.
+
+The `key_material` parameter is the SFrame `base_key` — raw key bytes that the SFrame library uses as input to HKDF for deriving the actual encryption keys (per RFC 9605 §4.4).
+
+### SFrame Decrypter Configuration and Interface (`api/sframe/sframe_decrypter_interface.h`)
+
+```mermaid
+classDiagram
+    class SframeDecrypterInit {
+        +cipher_suite: SframeCipherSuite
+    }
+
+    class SframeDecrypterInterface {
+        <<interface>>
+        +AddDecryptionKey(key_id: uint64_t, key_material: ArrayView~const uint8_t~) RTCError
+        +RemoveDecryptionKey(key_id: uint64_t) RTCError
+    }
+
+    SframeDecrypterInit --> SframeCipherSuite
+    RefCountInterface <|-- SframeDecrypterInterface
+```
+
+The decrypter init carries only `cipher_suite` — the mode (per-frame or per-packet) is inferred from the received SFrame payload descriptor's T bit. The decrypter supports multiple simultaneous keys to handle key rotation scenarios, where new keys are added before old keys are removed.
+
+### API on RtpSenderInterface (`api/rtp_sender_interface.h`)
+
+```cpp
+virtual RTCErrorOr<scoped_refptr<SframeEncrypterInterface>>
+CreateSframeEncrypterOrError(const SframeEncrypterInit& options) {
+  RTC_DCHECK_NOTREACHED();
+  return RTCError();
+}
+```
+
+Creates an internal SFrame encrypter, installs the appropriate transformer in the send pipeline, notifies the transceiver of SFrame activation, and returns a key management handle. The returned `SframeEncrypterInterface` is used solely for key management (`SetEncryptionKey`). Can only be called once per sender — subsequent calls return an error.
+
+**Errors:**
+- `UNSUPPORTED_OPERATION`: SFrame not yet implemented (stub)
+- `INVALID_MODIFICATION`: SFrame already activated on this transceiver
+
+### API on RtpReceiverInterface (`api/rtp_receiver_interface.h`)
+
+```cpp
+virtual RTCErrorOr<scoped_refptr<SframeDecrypterInterface>>
+CreateSframeDecrypterOrError(const SframeDecrypterInit& options) {
+  RTC_DCHECK_NOTREACHED();
+  return RTCError();
+}
+```
+
+Creates an internal SFrame decrypter, installs the appropriate transformer in the receive pipeline, notifies the transceiver of SFrame activation, and returns a key management handle. The returned `SframeDecrypterInterface` is used for key management (`AddDecryptionKey`, `RemoveDecryptionKey`). Can only be called once per receiver — subsequent calls return an error.
+
+**Errors:**
+- `UNSUPPORTED_OPERATION`: SFrame not yet implemented (stub)
+- `INVALID_MODIFICATION`: SFrame already activated on this transceiver
+
+## Internal Architecture
+
+### SframeActivationObserver
+
+When `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is called, the sender/receiver notifies its transceiver via the `SframeActivationObserver` callback. This follows the `SetStreamsObserver` pattern used throughout libwebrtc — a raw pointer to an observer interface, injected via constructor and stored as a `const` member.
+
+```mermaid
+classDiagram
+    class SframeActivationObserver {
+        <<interface>>
+        +OnSframeActivated() RTCError
+    }
+
+    class RtpTransceiver {
+        -sframe_activated_: std::optional~bool~
+        +OnSframeActivated() RTCError
+    }
+
+    class RtpSenderBase {
+        -sframe_activation_observer_: SframeActivationObserver* const
+    }
+
+    class RtpReceiverBase {
+        -sframe_activation_observer_: SframeActivationObserver* const
+    }
+
+    SframeActivationObserver <|.. RtpTransceiver
+    RtpSenderBase --> SframeActivationObserver : notifies
+    RtpReceiverBase --> SframeActivationObserver : notifies
+```
+
+**Transceiver state machine:**
+
+| `sframe_activated_` | Meaning | `OnSframeActivated()` result |
+|---|---|---|
+| `std::nullopt` | Not yet decided | Sets to `true`, returns OK |
+| `true` | Already activated | Returns OK (idempotent) |
+
+The transceiver's `sframe_activated_` field is used during SDP generation to determine whether `a=sframe` should be included in the corresponding media section. Once set to `true`, it cannot be reverted.
+
+**Constructor injection:** The observer pointer is passed via constructor to `RtpSenderBase` and `RtpReceiverBase`. The transceiver passes `this` when creating sender/receiver instances through the `CreateSender()` and `CreateReceiver()` helper functions.
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant Sender as RtpSenderBase
+    participant Observer as SframeActivationObserver (Transceiver)
+
+    App->>Sender: CreateSframeEncrypterOrError(options)
+    Sender->>Observer: OnSframeActivated()
+    Observer->>Observer: Check sframe_activated_
+
+    alt sframe_activated_ == nullopt
+        Observer->>Observer: Set sframe_activated_ = true
+        Observer-->>Sender: RTCError::OK()
+    else sframe_activated_ == true
+        Observer-->>Sender: RTCError::OK() (already activated)
+    end
+
+    Note over Sender: Create internal transformer
+    Note over Sender: Install transformer in pipeline
+    Sender-->>App: RTCErrorOr<SframeEncrypterInterface> handle
 ```
 
 ### Transformation Features Hierarchy
@@ -114,104 +246,24 @@ classDiagram
     TransformationFeatures <|-- PacketTransformerInterface
 ```
 
-> **Note**: The `GetReservedNumberOfBytes()` method in `PacketTransformerInterface` ensures that the packetizer reserves enough space for transformer data to avoid MTU overflow. This is critical for packet-level transformations where additional encryption overhead needs to be accommodated within network packet size constraints.
+> **Note**: The `GetReservedNumberOfBytes()` method in `PacketTransformerInterface` ensures that the packetizer reserves enough space for SFrame encryption overhead to avoid MTU overflow.
 
-### RTP Interface Integration
+### SFrameSenderTransformer (Internal)
 
-```mermaid
-classDiagram
-    class FrameTransformerHost {
-        <<interface>>
-        +SetFrameTransformer(transformer)
-        +SetPacketTransformer(transformer)
-        +~FrameTransformerHost()
-    }
-    
-    class RtpSenderInterface {
-        <<interface>>
-        +SetFrameTransformer(transformer)
-        +SetPacketTransformer(transformer)
-    }
-    
-    class RtpReceiverInterface {
-        <<interface>>
-        +SetFrameTransformer(transformer)
-        +SetPacketTransformer(transformer)
-    }
-    
-    FrameTransformerHost <|-- RtpSenderInterface
-    FrameTransformerHost <|-- RtpReceiverInterface
-```
-
-### SFrame Management Interfaces
+The `SFrameSenderTransformer` is an internal implementation class created by `RtpSenderBase::CreateSframeEncrypterOrError`. It provides SFrame encryption and exposes both the key management interface (returned to the app via proxy) and transformer interfaces (installed in the pipeline).
 
 ```mermaid
 classDiagram
-    class SFrameEncrypterInterface {
+    class SframeEncrypterInterface {
         <<interface>>
-        +SetEncryptionKey(key, key_id) bool
-    }
-    
-    class SFrameDecrypterInterface {
-        <<interface>>
-        +AddDecryptionKey(key, key_id) bool
-        +RemoveDecryptionKey(key_id) bool
-    }
-```
-
-> **Note**: These interfaces provide key management capabilities for SFrame transformers. The encrypter interface manages a single encryption key, while the decrypter interface can manage multiple decryption keys simultaneously to handle key rotation scenarios.
-
-For each of `SFrameEncrypterInterface` and `SFrameDecrypterInterface` proxy will be defined.
-To ensure that calls of `SetEncryptionKey` and `AddDecryptionKey`/`RemoveDecryptionKey` will be delegated to valid thread.
-
-
-## Configuration and Options
-
-```mermaid
-classDiagram
-    class SFrameMode {
-        <<enumeration>>
-        kFrame
-        kPacket
-    }
-    
-    class SFrameCipherSuite {
-        <<enumeration>>
-        kAES_128_CTR_HMAC_SHA256_80
-        kAES_128_CTR_HMAC_SHA256_64
-        kAES_128_CTR_HMAC_SHA256_32
-        kAES_128_GCM_SHA256_128
-        kAES_256_GCM_SHA512_128
-    }
-    
-    class SFrameTransformOptions {
-        +cipher_suite: SFrameCipherSuite
-        +sframe_mode: SFrameMode
-    }
-    
-    SFrameTransformOptions --> SFrameMode
-    SFrameTransformOptions --> SFrameCipherSuite
-```
-
-## Core objects
-
-### SFrameSenderTransformer
-
-The `SFrameSenderTransformer` provides SFrame encryption with factory methods to create appropriate transformer delegate.
-
-```mermaid
-classDiagram
-    class SFrameEncrypterInterface {
-        <<interface>>
-        +SetEncryptionKey(key, key_id) bool
+        +SetEncryptionKey(key_id, key_material) RTCError
     }
     
     class SFrameSenderTransformer {
-        -options: SFrameTransformOptions
-        -cipher_suite: SFrameCipherSuite
-        -sframe_mode: SFrameMode
-        +SFrameSenderTransformer(options)
-        +SetEncryptionKey(key, key_id) bool
+        -cipher_suite: SframeCipherSuite
+        -sframe_mode: SframeMode
+        +SFrameSenderTransformer(init)
+        +SetEncryptionKey(key_id, key_material) RTCError
         +TransformFrame(frame) TransformedFrame
         +TransformPacket(packet) TransformedPacket
         +GetReservedNumberOfBytes() size_t
@@ -219,123 +271,28 @@ classDiagram
         +AsPacketTransformer() PacketTransformerInterface*
     }
     
-    SFrameEncrypterInterface <|-- SFrameSenderTransformer
+    SframeEncrypterInterface <|-- SFrameSenderTransformer
 ```
 
-> **Diamond Inheritance Issue**: `SFrameSenderTransformer` cannot directly implement both `FrameTransformerInterface` and `PacketTransformerInterface` due to diamond inheritance from the common `TransformationFeatures` base interface. This would create ambiguity in method resolution and violate C++ inheritance rules. Therefore, the factory pattern with `AsFrameTransformer()` and `AsPacketTransformer()` methods is used to return separate wrapper objects that implement the respective interfaces.
+> **Diamond Inheritance**: `SFrameSenderTransformer` cannot directly implement both `FrameTransformerInterface` and `PacketTransformerInterface` due to diamond inheritance from the common `TransformationFeatures` base. The factory methods `AsFrameTransformer()` and `AsPacketTransformer()` return separate wrapper objects that implement the respective interfaces and delegate to the transformer.
 
-```mermaid
-sequenceDiagram
-    participant App as Application
-    participant ST as SFrameSenderTransformer
-    participant FW as FrameTransformer Wrapper
-    participant PW as PacketTransformer Wrapper
-    participant Sender as RtpSender
+### SFrameReceiverTransformer (Internal)
 
-    Note over App,Sender: SFrameSenderTransformer Setup and Usage Flow
-
-    App->>ST: Create SFrameSenderTransformer(options)
-    ST-->>App: Return transformer instance
-
-    alt sframe_mode == kFrame
-        App->>ST: AsFrameTransformer()
-        ST->>FW: Create internal FrameTransformer wrapper
-        FW-->>ST: Wrapper created
-        ST-->>App: Return FrameTransformerInterface*
-        
-        App->>Sender: SetFrameTransformer(wrapper)
-        Sender-->>App: Frame transformer assigned
-        
-        Note over FW,Sender: Frame transformation flow
-        Sender->>FW: Transform(frame)
-        FW->>ST: Delegate to SFrameSenderTransformer
-        ST-->>FW: Encrypted frame
-        FW-->>Sender: Return transformed frame
-        
-    else sframe_mode == kPacket
-        App->>ST: AsPacketTransformer()
-        ST->>PW: Create internal PacketTransformer wrapper
-        PW-->>ST: Wrapper created
-        ST-->>App: Return PacketTransformerInterface*
-        
-        App->>Sender: SetPacketTransformer(wrapper)
-        Sender-->>App: Packet transformer assigned
-        
-        Note over PW,Sender: Packet transformation flow
-        Sender->>PW: Transform(packet)
-        PW->>ST: Delegate to SFrameSenderTransformer
-        ST-->>PW: Encrypted packet
-        PW-->>Sender: Return transformed packet
-    end
-
-    Note over App,Sender: Transformer active in media pipeline
-```
-
-> **Architecture Benefits**: The unified `SFrameSenderTransformer` design provides a single encryption implementation that can be used for both frame and packet transformation through factory methods. This reduces code duplication while maintaining interface compatibility.
-
-> **Factory Methods**: `AsFrameTransformer()` and `AsPacketTransformer()` return wrapper objects that implement the respective interfaces and delegate transformation calls to the appropriate internal methods.
-
-> **MTU Consideration**: The `GetReservedNumberOfBytes()` method provides the encryption overhead size needed for packet transformation to prevent MTU overflow.
-
-### SFrameSenderTransform
+The `SFrameReceiverTransformer` is created by `RtpReceiverBase::CreateSframeDecrypterOrError`. It provides SFrame decryption with the same factory pattern for transformer interfaces.
 
 ```mermaid
 classDiagram
-    class SFrameSenderTransform {
-        -sender: RtpSenderInterface*
-        -worker_thread: Thread*
-        -transformer: SFrameEncrypterInterface* (proxy)
-        +SFrameSenderTransform(options, sender, thread)
-        +SetEncryptionKey(key, key_id) bool
-    }
-```
-
-The `SFrameSenderTransform` class serves as the main orchestrator for sender-side SFrame encryption. 
-The key architectural pattern is that the proxy wraps the transformer for thread safety:
-
-**Architecture Responsibilities:**
-
-- **SFrameSenderTransformer**: The unified encryption implementation with internal wrapper classes
-- **SFrameEncrypterProxy**: Thread-safe wrapper that marshals calls to the worker thread
-- **SFrameSenderTransform**: High-level orchestrator that manages the proxy-wrapped transformer
-
-**Key Design Elements:**
-
-- **Unified Implementation**: Single `SFrameSenderTransformer` handles both frame and packet encryption
-- **Internal Wrappers**: `AsFrameTransformer()` and `AsPacketTransformer()` return interface-specific wrappers
-- **Proxy Wrapping**: The proxy wraps the `SFrameSenderTransformer` instance for thread safety
-- **Thread Marshaling**: All `SetEncryptionKey()` calls are automatically routed to the worker thread
-
-**Initialization Flow:**
-1. `SFrameSenderTransform` constructor receives options, sender, and worker thread
-2. Creates `SFrameSenderTransformer` instance with encryption configuration
-3. Based on sframe mode, calls `AsFrameTransformer()` or `AsPacketTransformer()` to get interface wrapper
-4. Sets wrapper to corresponding transformation slot (`SetFrameTransformer`/`SetPacketTransformer`)
-5. Wraps transformer in `SFrameEncrypterProxy` for thread safety
-6. Stores the proxy as `transformer_`
-
-> **Thread Safety**: The proxy pattern ensures all key management operations are thread-safe by automatically marshaling calls from any thread to the designated worker thread, while maintaining the same interface as the underlying transformer.
-Transformer itself will always work on the worker thread, which will ensure that tranformer will get modified only from that one thread.
-
-### SFrameReceiverTransformer
-
-The `SFrameReceiverTransformer` provides SFrame decryption with factory methods to create appropriate transformer interfaces.
-
-```mermaid
-classDiagram
-    class SFrameDecrypterInterface {
+    class SframeDecrypterInterface {
         <<interface>>
-        +AddDecryptionKey(key, key_id) bool
-        +RemoveDecryptionKey(key_id) bool
+        +AddDecryptionKey(key_id, key_material) RTCError
+        +RemoveDecryptionKey(key_id) RTCError
     }
     
     class SFrameReceiverTransformer {
-        -options: SFrameTransformOptions
-        -cipher_suite: SFrameCipherSuite
-        -sframe_mode: SFrameMode
-        +SFrameReceiverTransformer(options)
-        +AddDecryptionKey(key, key_id) bool
-        +RemoveDecryptionKey(key_id) bool
+        -cipher_suite: SframeCipherSuite
+        +SFrameReceiverTransformer(init)
+        +AddDecryptionKey(key_id, key_material) RTCError
+        +RemoveDecryptionKey(key_id) RTCError
         +TransformFrame(frame) TransformedFrame
         +TransformPacket(packet) TransformedPacket
         +GetReservedNumberOfBytes() size_t
@@ -343,129 +300,109 @@ classDiagram
         +AsPacketTransformer() PacketTransformerInterface*
     }
     
-    SFrameDecrypterInterface <|-- SFrameReceiverTransformer
+    SframeDecrypterInterface <|-- SFrameReceiverTransformer
 ```
 
-> **Diamond Inheritance Issue**: `SFrameReceiverTransformer` cannot directly implement both `FrameTransformerInterface` and `PacketTransformerInterface` due to diamond inheritance from the common `TransformationFeatures` base interface. This would create ambiguity in method resolution and violate C++ inheritance rules. Therefore, the factory pattern with `AsFrameTransformer()` and `AsPacketTransformer()` methods is used to return separate wrapper objects that implement the respective interfaces.
+### CreateSframeEncrypterOrError Internal Flow
+
+When the application calls `CreateSframeEncrypterOrError`, the sender:
+1. Notifies the transceiver via the observer
+2. Creates the internal `SFrameSenderTransformer`
+3. Based on mode, gets the appropriate transformer wrapper and installs it in the pipeline
+4. Wraps the transformer in a thread-safe proxy
+5. Returns the proxy as the key management handle
 
 ```mermaid
 sequenceDiagram
     participant App as Application
-    participant RT as SFrameReceiverTransformer
-    participant FW as FrameTransformer Wrapper
-    participant PW as PacketTransformer Wrapper
-    participant Receiver as RtpReceiver
+    participant Sender as RtpSenderBase
+    participant Observer as SframeActivationObserver
+    participant Transformer as SFrameSenderTransformer
+    participant Proxy as SframeEncrypterProxy
+    participant Pipeline as Send Pipeline
 
-    Note over App,Receiver: SFrameReceiverTransformer Setup and Usage Flow
+    App->>Sender: CreateSframeEncrypterOrError(options)
 
-    App->>RT: Create SFrameReceiverTransformer(options)
-    RT-->>App: Return transformer instance
+    Sender->>Observer: OnSframeActivated()
+    Observer-->>Sender: RTCError::OK()
 
-    alt sframe_mode == kFrame
-        App->>RT: AsFrameTransformer()
-        RT->>FW: Create internal FrameTransformer wrapper
-        FW-->>RT: Wrapper created
-        RT-->>App: Return FrameTransformerInterface*
-        
-        App->>Receiver: SetFrameTransformer(wrapper)
-        Receiver-->>App: Frame transformer assigned
-        
-        Note over FW,Receiver: Frame transformation flow
-        Receiver->>FW: Transform(frame)
-        FW->>RT: Delegate to SFrameReceiverTransformer
-        RT-->>FW: Decrypted frame
-        FW-->>Receiver: Return transformed frame
-        
-    else sframe_mode == kPacket
-        App->>RT: AsPacketTransformer()
-        RT->>PW: Create internal PacketTransformer wrapper
-        PW-->>RT: Wrapper created
-        RT-->>App: Return PacketTransformerInterface*
-        
-        App->>Receiver: SetPacketTransformer(wrapper)
-        Receiver-->>App: Packet transformer assigned
-        
-        Note over PW,Receiver: Packet transformation flow
-        Receiver->>PW: Transform(packet)
-        PW->>RT: Delegate to SFrameReceiverTransformer
-        RT-->>PW: Decrypted packet
-        PW-->>Receiver: Return transformed packet
+    Sender->>Transformer: Create SFrameSenderTransformer(options)
+    Transformer-->>Sender: transformer instance
+
+    alt options.mode == kPerFrame
+        Sender->>Transformer: AsFrameTransformer()
+        Transformer-->>Sender: FrameTransformerInterface*
+        Sender->>Pipeline: SetFrameTransformer(wrapper)
+    else options.mode == kPerPacket
+        Sender->>Transformer: AsPacketTransformer()
+        Transformer-->>Sender: PacketTransformerInterface*
+        Sender->>Pipeline: SetPacketTransformer(wrapper)
     end
 
-    Note over App,Receiver: Transformer active in media pipeline
+    Sender->>Proxy: Wrap transformer as SframeEncrypterProxy
+    Note over Proxy: Thread-safe wrapper for key management
+
+    Sender-->>App: RTCErrorOr<scoped_refptr<SframeEncrypterInterface>>(proxy)
 ```
 
-> **Architecture Benefits**: The unified `SFrameReceiverTransformer` design provides a single decryption implementation that can be used for both frame and packet transformation through factory methods. This reduces code duplication while maintaining interface compatibility.
-
-> **Factory Methods**: `AsFrameTransformer()` and `AsPacketTransformer()` return wrapper objects that implement the respective interfaces and delegate transformation calls to the appropriate internal methods.
-
-> **Key Management**: The receiver transformer can manage multiple decryption keys simultaneously to handle key rotation scenarios, where new keys are added before old keys are removed to ensure seamless decryption during key transitions.
-
-### SFrameReceiverTransform
+### CreateSframeDecrypterOrError Internal Flow
 
 ```mermaid
-classDiagram
-    class SFrameReceiverTransform {
-        -receiver: RtpReceiverInterface*
-        -worker_thread: Thread*
-        -transformer: SFrameDecrypterInterface* (proxy)
-        +SFrameReceiverTransform(options, receiver, thread)
-        +AddDecryptionKey(key, key_id) bool
-        +RemoveDecryptionKey(key_id) bool
-    }
+sequenceDiagram
+    participant App as Application
+    participant Receiver as RtpReceiverBase
+    participant Observer as SframeActivationObserver
+    participant Transformer as SFrameReceiverTransformer
+    participant Proxy as SframeDecrypterProxy
+    participant Pipeline as Receive Pipeline
+
+    App->>Receiver: CreateSframeDecrypterOrError(options)
+
+    Receiver->>Observer: OnSframeActivated()
+    Observer-->>Receiver: RTCError::OK()
+
+    Receiver->>Transformer: Create SFrameReceiverTransformer(options)
+    Transformer-->>Receiver: transformer instance
+
+    Note over Receiver: Install appropriate transformer in pipeline
+    Receiver->>Pipeline: SetFrameTransformer() or SetPacketTransformer()
+
+    Receiver->>Proxy: Wrap transformer as SframeDecrypterProxy
+    Note over Proxy: Thread-safe wrapper for key management
+
+    Receiver-->>App: RTCErrorOr<scoped_refptr<SframeDecrypterInterface>>(proxy)
 ```
 
-The `SFrameReceiverTransform` class serves as the main orchestrator for receiver-side SFrame decryption. The key architectural pattern is that the proxy wraps the transformer for thread safety:
+## Key Management
 
-**Architecture Responsibilities:**
+### Thread Safety
 
-- **SFrameReceiverTransformer**: The unified decryption implementation with internal wrapper classes
-- **SFrameDecrypterProxy**: Thread-safe wrapper that marshals calls to the worker thread
-- **SFrameReceiverTransform**: High-level orchestrator that manages the proxy-wrapped transformer
+Key management calls on the returned `SframeEncrypterInterface` and `SframeDecrypterInterface` handles are thread-safe. The proxy pattern ensures all calls are marshaled to the worker thread:
 
-**Key Design Elements:**
+- **SframeEncrypterProxy**: Wraps `SFrameSenderTransformer`, marshals `SetEncryptionKey` to worker thread
+- **SframeDecrypterProxy**: Wraps `SFrameReceiverTransformer`, marshals `AddDecryptionKey`/`RemoveDecryptionKey` to worker thread
 
-- **Unified Implementation**: Single `SFrameReceiverTransformer` handles both frame and packet decryption
-- **Internal Wrappers**: `AsFrameTransformer()` and `AsPacketTransformer()` return interface-specific wrappers
-- **Proxy Wrapping**: The proxy wraps the `SFrameReceiverTransformer` instance for thread safety
-- **Thread Marshaling**: All `AddDecryptionKey()`/`RemoveDecryptionKey()` calls are automatically routed to the worker thread
-
-**Initialization Flow:**
-1. `SFrameReceiverTransform` constructor receives options, receiver, and worker thread
-2. Creates `SFrameReceiverTransformer` instance with decryption configuration
-3. Based on sframe mode, calls `AsFrameTransformer()` or `AsPacketTransformer()` to get interface wrapper
-4. Sets wrapper to corresponding transformation slot (`SetFrameTransformer`/`SetPacketTransformer`)
-5. Wraps transformer in `SFrameDecrypterProxy` for thread safety
-6. Stores the proxy as `transformer_`
-
-> **Thread Safety**: The proxy pattern ensures all key management operations are thread-safe by automatically marshaling calls from any thread to the designated worker thread. The transformer itself always works on the worker thread, ensuring single-threaded access to decryption state.
-
-## Media Pipeline Integration
-
-### Key Management Architecture
+The transformer itself always runs on the worker thread, ensuring single-threaded access to encryption/decryption state.
 
 ### Sender Key Management Flow
 
 ```mermaid
 sequenceDiagram
     participant App as Application
-    participant SenderTransform as SFrameSenderTransform
-    participant Proxy as SFrameEncrypterProxy
+    participant Proxy as SframeEncrypterProxy (returned handle)
     participant Transformer as SFrameSenderTransformer
 
-    App->>SenderTransform: SetEncryptionKey(key, key_id)
-    SenderTransform->>Proxy: SetEncryptionKey(key, key_id)
+    App->>Proxy: SetEncryptionKey(key_id, key_material)
     
     Note over Proxy: Calling Thread - Post task to worker thread
     Proxy->>Proxy: PostTask to Worker Thread
     
     Note over Transformer: Worker Thread - Execute key update
-    Proxy->>+Transformer: SetEncryptionKey(key, key_id)
-    Transformer-->>-Proxy: return success
+    Proxy->>+Transformer: SetEncryptionKey(key_id, key_material)
+    Transformer-->>-Proxy: RTCError::OK()
     
     Note over Proxy: Calling Thread - Return result
-    Proxy-->>SenderTransform: return success
-    SenderTransform-->>App: return success
+    Proxy-->>App: RTCError::OK()
     
     Note over App,Transformer: ✓ Key is now active for encryption
 ```
@@ -475,44 +412,42 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant App as Application
-    participant ReceiverTransform as SFrameReceiverTransform
-    participant Proxy as SFrameDecrypterProxy
+    participant Proxy as SframeDecrypterProxy (returned handle)
     participant Transformer as SFrameReceiverTransformer
 
-    App->>ReceiverTransform: AddDecryptionKey(key, key_id)
-    ReceiverTransform->>Proxy: AddDecryptionKey(key, key_id)
+    App->>Proxy: AddDecryptionKey(key_id, key_material)
     
     Note over Proxy: Calling Thread - Post task to worker thread
     Proxy->>Proxy: PostTask to Worker Thread
     
     Note over Transformer: Worker Thread - Execute add key
-    Proxy->>+Transformer: AddDecryptionKey(key, key_id)
-    Transformer-->>-Proxy: return success
+    Proxy->>+Transformer: AddDecryptionKey(key_id, key_material)
+    Transformer-->>-Proxy: RTCError::OK()
     
     Note over Proxy: Calling Thread - Return result
-    Proxy-->>ReceiverTransform: return success
-    ReceiverTransform-->>App: return success
+    Proxy-->>App: RTCError::OK()
     
     Note over App,Transformer: ✓ New key available for decryption
     
     Note over App: Later, during key rotation...
     
-    App->>ReceiverTransform: RemoveDecryptionKey(old_key_id)
-    ReceiverTransform->>Proxy: RemoveDecryptionKey(old_key_id)
+    App->>Proxy: RemoveDecryptionKey(old_key_id)
     
     Note over Proxy: Calling Thread - Post task to worker thread
     Proxy->>Proxy: PostTask to Worker Thread
     
     Note over Transformer: Worker Thread - Execute remove key
     Proxy->>+Transformer: RemoveDecryptionKey(old_key_id)
-    Transformer-->>-Proxy: return success
+    Transformer-->>-Proxy: RTCError::OK()
     
-    Note over Proxy: Calling Thread - Return result
-    Proxy-->>ReceiverTransform: return success
-    ReceiverTransform-->>App: return success
+    Proxy-->>App: RTCError::OK()
     
     Note over App,Transformer: ✓ Old key removed, only new key remains
 ```
+
+## Transformer Installation Flows
+
+These flows show how transformers propagate through the internal layers. In the new API, the sender/receiver calls these internally during `CreateSframeEncrypterOrError` / `CreateSframeDecrypterOrError` — the application does not call `SetFrameTransformer` / `SetPacketTransformer` directly for SFrame.
 
 ### RtpSender FrameTransformer Installation Flow
 
@@ -669,6 +604,8 @@ sequenceDiagram
     
     Note over ChannelReceive: Packet transformer now active for audio decryption
 ```
+
+## Media Processing Flows
 
 ### RtpSender Frame Processing Flow - Video
 

--- a/README.md
+++ b/README.md
@@ -290,9 +290,11 @@ sequenceDiagram
 
     Sender->>Pipeline: Install SFrame encrypter
     Note over Pipeline: Encrypter installed for encryption
+    Pipeline-->>Sender: installed
 
     Sender->>Proxy: Wrap encrypter as SframeEncrypterProxy
     Note over Proxy: Thread-safe wrapper for key management
+    Proxy-->>Sender: proxy instance
 
     Sender-->>App: RTCErrorOr<scoped_refptr<SframeEncrypterInterface>>(proxy)
 ```
@@ -320,9 +322,11 @@ sequenceDiagram
 
     Receiver->>Pipeline: Install SFrame decrypter
     Note over Pipeline: Decrypter installed for decryption
+    Pipeline-->>Receiver: installed
 
     Receiver->>Proxy: Wrap decrypter as SframeDecrypterProxy
     Note over Proxy: Thread-safe wrapper for key management
+    Proxy-->>Receiver: proxy instance
 
     Receiver-->>App: RTCErrorOr<scoped_refptr<SframeDecrypterInterface>>(proxy)
 ```

--- a/negotiation.md
+++ b/negotiation.md
@@ -23,36 +23,36 @@ This means:
 
 | Layer | Description |
 |-------|-------------|
-| **Application API** | `RtpSenderInterface::CreateSframeEncrypterOrError()` / `RtpReceiverInterface::CreateSframeDecrypterOrError()` — activates SFrame on the sender/receiver, which internally notifies the transceiver via `SframeActivationObserver` |
-| **Transceiver State** | `RtpTransceiver::sframe_activated_` (`std::optional<bool>`) — set to `true` when the observer callback fires, drives SDP generation |
+| **Application API** | `RtpSenderInterface::CreateSframeEncrypterOrError()` / `RtpReceiverInterface::CreateSframeDecrypterOrError()` — enables SFrame on the sender/receiver, which internally notifies the transceiver via `SframeStateObserver` |
+| **Transceiver State** | Each transceiver tracks an SFrame enabled state (not yet decided / enabled / disabled) — set to enabled when the observer callback fires, drives SDP generation |
 | **Offer/Answer** | SFrame preference is carried per media section during offer/answer creation |
 | **SDP Wire Format** | `a=sframe` attribute line present in the m= section when SFrame is enabled |
 
 ## SFrame Negotiation Rules
 
-1. **Opt-in only**: SFrame is disabled by default. The application must call `CreateSframeEncrypterOrError()` on the sender and/or `CreateSframeDecrypterOrError()` on the receiver to activate it. These calls internally notify the transceiver via the `SframeActivationObserver` callback.
-2. **No downgrade**: Once SFrame has been activated on a transceiver (via the observer callback), the `sframe_activated_` state is permanently `true`. Calling `CreateSframeEncrypterOrError`/`CreateSframeDecrypterOrError` again returns `INVALID_MODIFICATION` if the transceiver has already completed negotiation without SFrame.
+1. **Opt-in only**: SFrame is disabled by default. The application must call `CreateSframeEncrypterOrError()` on the sender and/or `CreateSframeDecrypterOrError()` on the receiver to enable it. These calls internally notify the transceiver via the `SframeStateObserver` callback.
+2. **No downgrade**: Once SFrame has been enabled on a transceiver (via the observer callback), the SFrame enabled state is permanent. Calling `CreateSframeEncrypterOrError`/`CreateSframeDecrypterOrError` again returns `INVALID_MODIFICATION` if the transceiver has already completed negotiation without SFrame.
 3. **Offers are never rejected for `a=sframe`**: Per the standard O/A model, the answerer accepts the offer and answers honestly — omitting `a=sframe` if it doesn't support SFrame.
 4. **Answers cannot introduce `a=sframe`**: If the offer did not include `a=sframe` for a media section, the answer must not add it. This is an RFC 3264 constraint — the answer is bounded by the offer. The SDP factory ensures answers only include `a=sframe` when both the offer and local preferences agree, and malicious answers that violate this are rejected.
 5. **Answer SFrame is negotiated, not copied**: The answer's `a=sframe` is only set when both the offer contains `a=sframe` AND the answerer's local preference has SFrame enabled. A mismatch is not an error at the SDP factory level; it simply means the answer lacks `a=sframe`.
 6. **Downgrade protection**: If a local offer included `a=sframe` but the remote answer does not, the offerer stops the transceiver. This is the primary mismatch-handling mechanism (per draft-ietf-avtcore-rtp-sframe §6).
-7. **New transceivers inherit SFrame from offers**: When a remote offer creates a new transceiver (no local match), the transceiver inherits `sframe_activated_ = true` from the offer.
-8. **Triggers negotiation**: When `SframeActivationObserver::OnSframeActivated()` sets `sframe_activated_` from `nullopt` to `true`, this triggers the `onnegotiationneeded` event, initiating a new offer/answer exchange.
+7. **New transceivers inherit SFrame from offers**: When a remote offer creates a new transceiver (no local match), the transceiver is created with SFrame already enabled based on the offer.
+8. **Triggers negotiation**: When the state observer transitions the transceiver's SFrame state from undecided to enabled, this triggers the negotiation-needed event, initiating a new offer/answer exchange.
 
 ## Transceiver SFrame State
 
-Each `RtpTransceiver` has an `std::optional<bool> sframe_activated_` field, updated internally via the `SframeActivationObserver` callback (not directly by the application):
+Each transceiver tracks an SFrame enabled state, updated internally via the state observer callback (not directly by the application):
 
-| Value | Meaning |
+| State | Meaning |
 |-------|--------|
-| `std::nullopt` | Not yet decided — SFrame has not been activated on sender or receiver |
-| `true` | SFrame activated (set when `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is called on the sender/receiver, which triggers `OnSframeActivated()`) |
+| Not yet decided | SFrame has not been enabled on sender or receiver |
+| Enabled | SFrame is active (set when `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is called on the sender/receiver, which triggers the observer) |
 
-The transceiver implements `SframeActivationObserver`. When `OnSframeActivated()` is called:
-- If `sframe_activated_ == std::nullopt`: sets to `true`, returns OK, triggers negotiation-needed
-- If `sframe_activated_ == true`: returns OK (idempotent — both sender and receiver may call it)
+The transceiver implements the state observer. When the callback fires:
+- If SFrame is not yet decided: marks it as enabled, returns OK, triggers negotiation-needed
+- If SFrame is already enabled: returns OK (idempotent — both sender and receiver may call it)
 
-Once the first negotiation completes without SFrame (because the application never called `CreateSframeEncrypterOrError`/`CreateSframeDecrypterOrError`), subsequent attempts to activate SFrame return `INVALID_MODIFICATION`.
+Once the first negotiation completes without SFrame (because the application never called `CreateSframeEncrypterOrError`/`CreateSframeDecrypterOrError`), subsequent attempts to enable SFrame return `INVALID_MODIFICATION`.
 
 ---
 
@@ -82,7 +82,7 @@ The attribute follows `draft-ietf-avtcore-rtp-sframe`:
 
 ### Flow 1: Successful SFrame Enablement (Both Sides)
 
-The happy path where both peers activate SFrame and negotiate successfully.
+The happy path where both peers enable SFrame and negotiate successfully.
 The offerer uses `AddTransceiver` while the answerer uses `addTrack` — per JSEP §5.10, only `addTrack`-created transceivers are eligible for matching when processing a remote offer.
 
 ```mermaid
@@ -97,14 +97,14 @@ sequenceDiagram
     participant SB as Sender B
     participant AppB as Application B
 
-    Note over AppA,AppB: Both applications create transceivers and activate SFrame
+    Note over AppA,AppB: Both applications create transceivers and enable SFrame
 
     AppA->>PCA: AddTransceiver(audio)
     PCA-->>AppA: transceiver A (with sender A, receiver A)
 
     AppA->>SA: CreateSframeEncrypterOrError(options)
-    SA->>TA: OnSframeActivated() via observer
-    Note over TA: sframe_activated_ = true
+    SA->>TA: TryEnableSframe() via observer
+    Note over TA: SFrame marked as enabled
     SA-->>AppA: RTCErrorOr<SframeEncrypterInterface> (key handle)
 
     PCA-->>AppA: onnegotiationneeded
@@ -113,8 +113,8 @@ sequenceDiagram
     PCB-->>AppB: transceiver B (matchable per JSEP §5.10)
 
     AppB->>SB: CreateSframeEncrypterOrError(options)
-    SB->>TB: OnSframeActivated() via observer
-    Note over TB: sframe_activated_ = true
+    SB->>TB: TryEnableSframe() via observer
+    Note over TB: SFrame marked as enabled
     SB-->>AppB: RTCErrorOr<SframeEncrypterInterface> (key handle)
 
     Note over AppA,AppB: Offer/Answer Exchange
@@ -144,9 +144,9 @@ sequenceDiagram
 
 ---
 
-### Flow 2: Offerer Activates SFrame, Answerer Does Not — Transceiver Stopped
+### Flow 2: Offerer Enables SFrame, Answerer Does Not — Transceiver Stopped
 
-The offerer activates SFrame but the answerer does not. Per the standard O/A model, the offer is **accepted** (not rejected). The answerer creates an answer without `a=sframe`. When the offerer processes the answer, it detects the mismatch and **stops the transceiver**.
+The offerer enables SFrame but the answerer does not. Per the standard O/A model, the offer is **accepted** (not rejected). The answerer creates an answer without `a=sframe`. When the offerer processes the answer, it detects the mismatch and **stops the transceiver**.
 
 ```mermaid
 sequenceDiagram
@@ -163,8 +163,8 @@ sequenceDiagram
     PCA-->>AppA: transceiver A
 
     AppA->>SA: CreateSframeEncrypterOrError(options)
-    SA->>TA: OnSframeActivated()
-    Note over TA: sframe_activated_ = true
+    SA->>TA: TryEnableSframe()
+    Note over TA: SFrame marked as enabled
     SA-->>AppA: key handle
     PCA-->>AppA: onnegotiationneeded
 
@@ -183,7 +183,7 @@ sequenceDiagram
     Note over PCB: ✅ Offer accepted (standard O/A model)
 
     AppB->>PCB: CreateAnswer()
-    Note over PCB: Local transceiver sframe_activated_ == nullopt<br/>→ answer WITHOUT "a=sframe"
+    Note over PCB: Local transceiver has SFrame undecided<br/>→ answer WITHOUT "a=sframe"
     PCB-->>AppB: SDP Answer WITHOUT "a=sframe"
 
     AppB->>PCB: SetLocalDescription(answer)
@@ -268,8 +268,8 @@ sequenceDiagram
     PCA-->>AppA: transceiver A
 
     AppA->>SA: CreateSframeEncrypterOrError(options)
-    SA->>TA: OnSframeActivated()
-    Note over TA: sframe_activated_ = true
+    SA->>TA: TryEnableSframe()
+    Note over TA: SFrame marked as enabled
     SA-->>AppA: key handle
 
     AppA->>PCA: CreateOffer()
@@ -282,7 +282,7 @@ sequenceDiagram
     SDP->>AppB: Receive offer with new m= section containing "a=sframe"
     AppB->>PCB: SetRemoteDescription(offer)
     Note over PCB: No existing transceiver for this m= section
-    PCB->>TB: Create new transceiver with sframe_activated_ = true
+    PCB->>TB: Create new transceiver with SFrame enabled
     Note over TB: Inherits SFrame state from remote offer
 
     AppB->>PCB: CreateAnswer()
@@ -314,15 +314,15 @@ sequenceDiagram
 ### What is NOT done (by design)
 
 - **Offers are never rejected for `a=sframe`**: The answerer accepts the offer and answers honestly. The offerer handles mismatches.
-- **SFrame is not auto-enabled on existing transceivers**: When an existing transceiver does not have SFrame activated, the remote offer's `a=sframe` does not auto-activate it. SFrame is an encryption feature requiring explicit opt-in via `CreateSframeEncrypterOrError`/`CreateSframeDecrypterOrError` and key management infrastructure.
+- **SFrame is not auto-enabled on existing transceivers**: When an existing transceiver does not have SFrame enabled, the remote offer's `a=sframe` does not auto-enable it. SFrame is an encryption feature requiring explicit opt-in via `CreateSframeEncrypterOrError`/`CreateSframeDecrypterOrError` and key management infrastructure.
 
 ---
 
 ## Additional Scenarios
 
-### Negotiation-Needed Triggered by SFrame Activation
+### Negotiation-Needed Triggered by SFrame Enablement
 
-When `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is called, the sender/receiver notifies the transceiver via the `SframeActivationObserver`. This sets `sframe_activated_` to `true`, which differs from what was last negotiated, triggering a new offer/answer round.
+When `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is called, the sender/receiver notifies the transceiver via the state observer. This marks SFrame as enabled on the transceiver, which differs from what was last negotiated, triggering a new offer/answer round.
 
 ```mermaid
 sequenceDiagram
@@ -331,11 +331,11 @@ sequenceDiagram
     participant T as RtpTransceiver
     participant PC as PeerConnection
 
-    Note over App,T: Initial state: SFrame not activated, media flowing
+    Note over App,T: Initial state: SFrame not enabled, media flowing
 
     App->>S: CreateSframeEncrypterOrError(options)
-    S->>T: OnSframeActivated()
-    Note over T: sframe_activated_ = true
+    S->>T: TryEnableSframe()
+    Note over T: SFrame marked as enabled
     S-->>App: RTCErrorOr<SframeEncrypterInterface>
 
     PC-->>App: onnegotiationneeded
@@ -349,9 +349,9 @@ sequenceDiagram
 
 ---
 
-### SFrame Cannot Be Activated After Negotiation Without It
+### SFrame Cannot Be Enabled After Negotiation Without It
 
-If a transceiver completes a negotiation round without SFrame activated, `SetLocalDescription(answer)` locks the SFrame state. After that, calling `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is rejected because the observer returns `INVALID_MODIFICATION`.
+If a transceiver completes a negotiation round without SFrame enabled, `SetLocalDescription(answer)` locks the SFrame state. After that, calling `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is rejected because the observer returns `INVALID_MODIFICATION`.
 
 ```mermaid
 sequenceDiagram
@@ -370,15 +370,15 @@ sequenceDiagram
     App->>PC: CreateAnswer()
     PC-->>App: Answer without "a=sframe"
     App->>PC: SetLocalDescription(answer)
-    Note over T: sframe_activated_ remains nullopt<br/>→ locked after first negotiation
+    Note over T: SFrame state remains undecided<br/>→ locked after first negotiation
 
-    Note over App,T: Later, application tries to activate SFrame...
+    Note over App,T: Later, application tries to enable SFrame...
 
     App->>S: CreateSframeEncrypterOrError(options)
-    S->>T: OnSframeActivated()
+    S->>T: TryEnableSframe()
     T-->>S: ❌ INVALID_MODIFICATION
     S-->>App: RTCError(INVALID_MODIFICATION)
-    Note over App: "Cannot activate SFrame after<br/>negotiation completed without it"
+    Note over App: "Cannot enable SFrame after<br/>negotiation completed without it"
 ```
 
 > **Key point:** `CreateSframeEncrypterOrError`/`CreateSframeDecrypterOrError` must be called **before** the first negotiation completes. Once `SetLocalDescription(answer)` is called without SFrame, the transceiver's SFrame state is permanently locked.

--- a/negotiation.md
+++ b/negotiation.md
@@ -23,34 +23,36 @@ This means:
 
 | Layer | Description |
 |-------|-------------|
-| **Application API** | `RtpTransceiverInterface::SetUseSFrame()` / `UseSFrame()` — the application's intent |
+| **Application API** | `RtpSenderInterface::CreateSframeEncrypterOrError()` / `RtpReceiverInterface::CreateSframeDecrypterOrError()` — activates SFrame on the sender/receiver, which internally notifies the transceiver via `SframeActivationObserver` |
+| **Transceiver State** | `RtpTransceiver::sframe_activated_` (`std::optional<bool>`) — set to `true` when the observer callback fires, drives SDP generation |
 | **Offer/Answer** | SFrame preference is carried per media section during offer/answer creation |
 | **SDP Wire Format** | `a=sframe` attribute line present in the m= section when SFrame is enabled |
 
 ## SFrame Negotiation Rules
 
-1. **Opt-in only**: SFrame is disabled by default. The application must call `SetUseSFrame()` to enable it.
-2. **No downgrade**: Once SFrame has been set, it cannot be re-enabled after being explicitly disabled. Attempting to do so returns `InvalidModification`.
+1. **Opt-in only**: SFrame is disabled by default. The application must call `CreateSframeEncrypterOrError()` on the sender and/or `CreateSframeDecrypterOrError()` on the receiver to activate it. These calls internally notify the transceiver via the `SframeActivationObserver` callback.
+2. **No downgrade**: Once SFrame has been activated on a transceiver (via the observer callback), the `sframe_activated_` state is permanently `true`. Calling `CreateSframeEncrypterOrError`/`CreateSframeDecrypterOrError` again returns `INVALID_MODIFICATION` if the transceiver has already completed negotiation without SFrame.
 3. **Offers are never rejected for `a=sframe`**: Per the standard O/A model, the answerer accepts the offer and answers honestly — omitting `a=sframe` if it doesn't support SFrame.
 4. **Answers cannot introduce `a=sframe`**: If the offer did not include `a=sframe` for a media section, the answer must not add it. This is an RFC 3264 constraint — the answer is bounded by the offer. The SDP factory ensures answers only include `a=sframe` when both the offer and local preferences agree, and malicious answers that violate this are rejected.
 5. **Answer SFrame is negotiated, not copied**: The answer's `a=sframe` is only set when both the offer contains `a=sframe` AND the answerer's local preference has SFrame enabled. A mismatch is not an error at the SDP factory level; it simply means the answer lacks `a=sframe`.
 6. **Downgrade protection**: If a local offer included `a=sframe` but the remote answer does not, the offerer stops the transceiver. This is the primary mismatch-handling mechanism (per draft-ietf-avtcore-rtp-sframe §6).
-7. **New transceivers inherit SFrame from offers**: When a remote offer creates a new transceiver (no local match), the transceiver inherits `use_sframe` from the offer.
-8. **Triggers negotiation**: Changing the SFrame state triggers the `onnegotiationneeded` event, initiating a new offer/answer exchange.
+7. **New transceivers inherit SFrame from offers**: When a remote offer creates a new transceiver (no local match), the transceiver inherits `sframe_activated_ = true` from the offer.
+8. **Triggers negotiation**: When `SframeActivationObserver::OnSframeActivated()` sets `sframe_activated_` from `nullopt` to `true`, this triggers the `onnegotiationneeded` event, initiating a new offer/answer exchange.
 
 ## Transceiver SFrame State
 
-Each `RtpTransceiver` has an `std::optional<bool> use_sframe_` field:
+Each `RtpTransceiver` has an `std::optional<bool> sframe_activated_` field, updated internally via the `SframeActivationObserver` callback (not directly by the application):
 
 | Value | Meaning |
-|-------|---------|
-| `std::nullopt` | Not yet decided — no negotiation has occurred |
-| `true` | SFrame enabled (set via `SetUseSFrame()` before first negotiation) |
-| `false` | SFrame disabled (locked after first negotiation without SFrame) |
+|-------|--------|
+| `std::nullopt` | Not yet decided — SFrame has not been activated on sender or receiver |
+| `true` | SFrame activated (set when `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is called on the sender/receiver, which triggers `OnSframeActivated()`) |
 
-Once locked (after the first completed negotiation), the value cannot change:
-calling `SetUseSFrame()` on a transceiver with `UseSFrame() == false` returns
-`INVALID_MODIFICATION`.
+The transceiver implements `SframeActivationObserver`. When `OnSframeActivated()` is called:
+- If `sframe_activated_ == std::nullopt`: sets to `true`, returns OK, triggers negotiation-needed
+- If `sframe_activated_ == true`: returns OK (idempotent — both sender and receiver may call it)
+
+Once the first negotiation completes without SFrame (because the application never called `CreateSframeEncrypterOrError`/`CreateSframeDecrypterOrError`), subsequent attempts to activate SFrame return `INVALID_MODIFICATION`.
 
 ---
 
@@ -80,31 +82,40 @@ The attribute follows `draft-ietf-avtcore-rtp-sframe`:
 
 ### Flow 1: Successful SFrame Enablement (Both Sides)
 
-The happy path where both peers enable SFrame and negotiate successfully.
+The happy path where both peers activate SFrame and negotiate successfully.
 The offerer uses `AddTransceiver` while the answerer uses `addTrack` — per JSEP §5.10, only `addTrack`-created transceivers are eligible for matching when processing a remote offer.
 
 ```mermaid
 sequenceDiagram
     participant AppA as Application A
+    participant SA as Sender A
     participant TA as Transceiver A
     participant PCA as PeerConnection A
     participant SDP as SDP Exchange
     participant PCB as PeerConnection B
     participant TB as Transceiver B
+    participant SB as Sender B
     participant AppB as Application B
 
-    Note over AppA,AppB: Both applications create transceivers and enable SFrame
+    Note over AppA,AppB: Both applications create transceivers and activate SFrame
 
     AppA->>PCA: AddTransceiver(audio)
-    PCA-->>AppA: transceiver A
-    AppA->>TA: SetUseSFrame()
-    TA-->>AppA: OK
+    PCA-->>AppA: transceiver A (with sender A, receiver A)
+
+    AppA->>SA: CreateSframeEncrypterOrError(options)
+    SA->>TA: OnSframeActivated() via observer
+    Note over TA: sframe_activated_ = true
+    SA-->>AppA: RTCErrorOr<SframeEncrypterInterface> (key handle)
+
     PCA-->>AppA: onnegotiationneeded
 
     AppB->>PCB: addTrack(audioTrack)
     PCB-->>AppB: transceiver B (matchable per JSEP §5.10)
-    AppB->>TB: SetUseSFrame()
-    TB-->>AppB: OK
+
+    AppB->>SB: CreateSframeEncrypterOrError(options)
+    SB->>TB: OnSframeActivated() via observer
+    Note over TB: sframe_activated_ = true
+    SB-->>AppB: RTCErrorOr<SframeEncrypterInterface> (key handle)
 
     Note over AppA,AppB: Offer/Answer Exchange
 
@@ -133,13 +144,14 @@ sequenceDiagram
 
 ---
 
-### Flow 2: Offerer Enables SFrame, Answerer Does Not — Transceiver Stopped
+### Flow 2: Offerer Activates SFrame, Answerer Does Not — Transceiver Stopped
 
-The offerer enables SFrame but the answerer does not. Per the standard O/A model, the offer is **accepted** (not rejected). The answerer creates an answer without `a=sframe`. When the offerer processes the answer, it detects the mismatch and **stops the transceiver**.
+The offerer activates SFrame but the answerer does not. Per the standard O/A model, the offer is **accepted** (not rejected). The answerer creates an answer without `a=sframe`. When the offerer processes the answer, it detects the mismatch and **stops the transceiver**.
 
 ```mermaid
 sequenceDiagram
     participant AppA as Application A
+    participant SA as Sender A
     participant TA as Transceiver A
     participant PCA as PeerConnection A
     participant SDP as SDP Exchange
@@ -149,13 +161,16 @@ sequenceDiagram
 
     AppA->>PCA: AddTransceiver(audio)
     PCA-->>AppA: transceiver A
-    AppA->>TA: SetUseSFrame()
-    TA-->>AppA: OK
+
+    AppA->>SA: CreateSframeEncrypterOrError(options)
+    SA->>TA: OnSframeActivated()
+    Note over TA: sframe_activated_ = true
+    SA-->>AppA: key handle
     PCA-->>AppA: onnegotiationneeded
 
     AppB->>PCB: addTrack(audioTrack)
     PCB-->>AppB: transceiver B (matchable per JSEP §5.10)
-    Note over AppB,TB: Application B does NOT call SetUseSFrame()
+    Note over AppB,TB: Application B does NOT call<br/>CreateSframeEncrypterOrError or CreateSframeDecrypterOrError
 
     AppA->>PCA: CreateOffer()
     PCA-->>AppA: SDP Offer with "a=sframe"
@@ -168,7 +183,7 @@ sequenceDiagram
     Note over PCB: ✅ Offer accepted (standard O/A model)
 
     AppB->>PCB: CreateAnswer()
-    Note over PCB: Local transceiver does not have SFrame<br/>→ answer WITHOUT "a=sframe"
+    Note over PCB: Local transceiver sframe_activated_ == nullopt<br/>→ answer WITHOUT "a=sframe"
     PCB-->>AppB: SDP Answer WITHOUT "a=sframe"
 
     AppB->>PCB: SetLocalDescription(answer)
@@ -203,7 +218,7 @@ sequenceDiagram
 
     AppA->>PCA: AddTransceiver(audio)
     PCA-->>AppA: transceiver A
-    Note over AppA,TA: Offerer does NOT call SetUseSFrame()
+    Note over AppA,TA: Offerer does NOT call CreateSframeEncrypterOrError()
 
     AppA->>PCA: CreateOffer()
     PCA-->>AppA: SDP Offer WITHOUT "a=sframe"
@@ -241,6 +256,7 @@ When a remote offer contains a new m= section with `a=sframe`, the answerer has 
 ```mermaid
 sequenceDiagram
     participant AppA as Application A (Offerer)
+    participant SA as Sender A
     participant TA as Transceiver A
     participant PCA as PeerConnection A
     participant SDP as SDP Exchange
@@ -250,8 +266,11 @@ sequenceDiagram
 
     AppA->>PCA: AddTransceiver(audio)
     PCA-->>AppA: transceiver A
-    AppA->>TA: SetUseSFrame()
-    TA-->>AppA: OK
+
+    AppA->>SA: CreateSframeEncrypterOrError(options)
+    SA->>TA: OnSframeActivated()
+    Note over TA: sframe_activated_ = true
+    SA-->>AppA: key handle
 
     AppA->>PCA: CreateOffer()
     PCA-->>AppA: SDP Offer with "a=sframe"
@@ -263,7 +282,7 @@ sequenceDiagram
     SDP->>AppB: Receive offer with new m= section containing "a=sframe"
     AppB->>PCB: SetRemoteDescription(offer)
     Note over PCB: No existing transceiver for this m= section
-    PCB->>TB: Create new transceiver with SFrame enabled
+    PCB->>TB: Create new transceiver with sframe_activated_ = true
     Note over TB: Inherits SFrame state from remote offer
 
     AppB->>PCB: CreateAnswer()
@@ -295,26 +314,29 @@ sequenceDiagram
 ### What is NOT done (by design)
 
 - **Offers are never rejected for `a=sframe`**: The answerer accepts the offer and answers honestly. The offerer handles mismatches.
-- **SFrame is not auto-enabled on existing transceivers**: When an existing transceiver does not have SFrame enabled, the remote offer's `a=sframe` does not auto-enable it. SFrame is an encryption feature requiring explicit opt-in and key management infrastructure.
+- **SFrame is not auto-enabled on existing transceivers**: When an existing transceiver does not have SFrame activated, the remote offer's `a=sframe` does not auto-activate it. SFrame is an encryption feature requiring explicit opt-in via `CreateSframeEncrypterOrError`/`CreateSframeDecrypterOrError` and key management infrastructure.
 
 ---
 
 ## Additional Scenarios
 
-### Negotiation-Needed Triggered by SFrame State Change
+### Negotiation-Needed Triggered by SFrame Activation
 
-When the transceiver's SFrame state differs from what was last negotiated, a new offer/answer round is triggered.
+When `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is called, the sender/receiver notifies the transceiver via the `SframeActivationObserver`. This sets `sframe_activated_` to `true`, which differs from what was last negotiated, triggering a new offer/answer round.
 
 ```mermaid
 sequenceDiagram
     participant App as Application
-    participant PC as PeerConnection
+    participant S as Sender
     participant T as RtpTransceiver
+    participant PC as PeerConnection
 
-    Note over App,T: Initial state: SFrame not enabled, media flowing
+    Note over App,T: Initial state: SFrame not activated, media flowing
 
-    App->>T: SetUseSFrame()
-    T-->>App: OK
+    App->>S: CreateSframeEncrypterOrError(options)
+    S->>T: OnSframeActivated()
+    Note over T: sframe_activated_ = true
+    S-->>App: RTCErrorOr<SframeEncrypterInterface>
 
     PC-->>App: onnegotiationneeded
     Note over PC: Transceiver's SFrame state differs from<br/>what was last negotiated → needs renegotiation
@@ -327,19 +349,20 @@ sequenceDiagram
 
 ---
 
-### SFrame Cannot Be Enabled After Negotiation Without It
+### SFrame Cannot Be Activated After Negotiation Without It
 
-If a transceiver completes a negotiation round without SFrame enabled, the answerer's `SetLocalDescription(answer)` locks the SFrame state to `false`. After that, calling `SetUseSFrame()` is rejected.
+If a transceiver completes a negotiation round without SFrame activated, `SetLocalDescription(answer)` locks the SFrame state. After that, calling `CreateSframeEncrypterOrError` or `CreateSframeDecrypterOrError` is rejected because the observer returns `INVALID_MODIFICATION`.
 
 ```mermaid
 sequenceDiagram
     participant App as Application (Answerer)
+    participant S as Sender
     participant T as Transceiver
     participant PC as PeerConnection
 
     App->>PC: AddTransceiver(audio)
-    PC-->>App: transceiver
-    Note over App,T: Application does NOT call SetUseSFrame()
+    PC-->>App: transceiver (with sender, receiver)
+    Note over App,T: Application does NOT call<br/>CreateSframeEncrypterOrError or CreateSframeDecrypterOrError
 
     Note over App,PC: Offer/Answer exchange completes without a=sframe
 
@@ -347,14 +370,16 @@ sequenceDiagram
     App->>PC: CreateAnswer()
     PC-->>App: Answer without "a=sframe"
     App->>PC: SetLocalDescription(answer)
-    Note over T: use_sframe is now locked to false
+    Note over T: sframe_activated_ remains nullopt<br/>→ locked after first negotiation
 
-    Note over App,T: Later, application tries to enable SFrame...
+    Note over App,T: Later, application tries to activate SFrame...
 
-    App->>T: SetUseSFrame()
-    T-->>App: ❌ InvalidModification
-    Note over App: "Cannot set useSFrame to true<br/>after it has been set to false"
+    App->>S: CreateSframeEncrypterOrError(options)
+    S->>T: OnSframeActivated()
+    T-->>S: ❌ INVALID_MODIFICATION
+    S-->>App: RTCError(INVALID_MODIFICATION)
+    Note over App: "Cannot activate SFrame after<br/>negotiation completed without it"
 ```
 
-> **Key point:** `SetUseSFrame()` must be called **before** the first negotiation completes. Once `SetLocalDescription(answer)` is called without SFrame, the transceiver's SFrame state is permanently locked to `false`.
+> **Key point:** `CreateSframeEncrypterOrError`/`CreateSframeDecrypterOrError` must be called **before** the first negotiation completes. Once `SetLocalDescription(answer)` is called without SFrame, the transceiver's SFrame state is permanently locked.
 

--- a/negotiation.md
+++ b/negotiation.md
@@ -105,6 +105,7 @@ sequenceDiagram
     AppA->>SA: CreateSframeEncrypterOrError(options)
     SA->>TA: TryEnableSframe() via observer
     Note over TA: SFrame marked as enabled
+    TA-->>SA: RTCError::OK()
     SA-->>AppA: RTCErrorOr<SframeEncrypterInterface> (key handle)
 
     PCA-->>AppA: onnegotiationneeded
@@ -115,6 +116,7 @@ sequenceDiagram
     AppB->>SB: CreateSframeEncrypterOrError(options)
     SB->>TB: TryEnableSframe() via observer
     Note over TB: SFrame marked as enabled
+    TB-->>SB: RTCError::OK()
     SB-->>AppB: RTCErrorOr<SframeEncrypterInterface> (key handle)
 
     Note over AppA,AppB: Offer/Answer Exchange
@@ -165,6 +167,7 @@ sequenceDiagram
     AppA->>SA: CreateSframeEncrypterOrError(options)
     SA->>TA: TryEnableSframe()
     Note over TA: SFrame marked as enabled
+    TA-->>SA: RTCError::OK()
     SA-->>AppA: key handle
     PCA-->>AppA: onnegotiationneeded
 
@@ -270,6 +273,7 @@ sequenceDiagram
     AppA->>SA: CreateSframeEncrypterOrError(options)
     SA->>TA: TryEnableSframe()
     Note over TA: SFrame marked as enabled
+    TA-->>SA: RTCError::OK()
     SA-->>AppA: key handle
 
     AppA->>PCA: CreateOffer()
@@ -336,6 +340,7 @@ sequenceDiagram
     App->>S: CreateSframeEncrypterOrError(options)
     S->>T: TryEnableSframe()
     Note over T: SFrame marked as enabled
+    T-->>S: RTCError::OK()
     S-->>App: RTCErrorOr<SframeEncrypterInterface>
 
     PC-->>App: onnegotiationneeded

--- a/negotiation.md
+++ b/negotiation.md
@@ -23,14 +23,14 @@ This means:
 
 | Layer | Description |
 |-------|-------------|
-| **Application API** | `RtpSenderInterface::CreateSframeEncrypterOrError()` / `RtpReceiverInterface::CreateSframeDecrypterOrError()` — enables SFrame on the sender/receiver, which internally notifies the transceiver via `SframeStateObserver` |
+| **Application API** | `RtpSenderInterface::CreateSframeEncrypterOrError()` / `RtpReceiverInterface::CreateSframeDecrypterOrError()` — enables SFrame on the sender/receiver, which internally notifies the transceiver via `SframeEnablementDelegate` |
 | **Transceiver State** | Each transceiver tracks an SFrame enabled state (not yet decided / enabled / disabled) — set to enabled when the observer callback fires, drives SDP generation |
 | **Offer/Answer** | SFrame preference is carried per media section during offer/answer creation |
 | **SDP Wire Format** | `a=sframe` attribute line present in the m= section when SFrame is enabled |
 
 ## SFrame Negotiation Rules
 
-1. **Opt-in only**: SFrame is disabled by default. The application must call `CreateSframeEncrypterOrError()` on the sender and/or `CreateSframeDecrypterOrError()` on the receiver to enable it. These calls internally notify the transceiver via the `SframeStateObserver` callback.
+1. **Opt-in only**: SFrame is disabled by default. The application must call `CreateSframeEncrypterOrError()` on the sender and/or `CreateSframeDecrypterOrError()` on the receiver to enable it. These calls internally notify the transceiver via the `SframeEnablementDelegate` callback.
 2. **No downgrade**: Once SFrame has been enabled on a transceiver (via the observer callback), the SFrame enabled state is permanent. Calling `CreateSframeEncrypterOrError`/`CreateSframeDecrypterOrError` again returns `INVALID_MODIFICATION` if the transceiver has already completed negotiation without SFrame.
 3. **Offers are never rejected for `a=sframe`**: Per the standard O/A model, the answerer accepts the offer and answers honestly — omitting `a=sframe` if it doesn't support SFrame.
 4. **Answers cannot introduce `a=sframe`**: If the offer did not include `a=sframe` for a media section, the answer must not add it. This is an RFC 3264 constraint — the answer is bounded by the offer. The SDP factory ensures answers only include `a=sframe` when both the offer and local preferences agree, and malicious answers that violate this are rejected.
@@ -103,7 +103,7 @@ sequenceDiagram
     PCA-->>AppA: transceiver A (with sender A, receiver A)
 
     AppA->>SA: CreateSframeEncrypterOrError(options)
-    SA->>TA: TryEnableSframe() via observer
+    SA->>TA: TryToEnableSframe() via observer
     Note over TA: SFrame marked as enabled
     TA-->>SA: RTCError::OK()
     SA-->>AppA: RTCErrorOr<SframeEncrypterInterface> (key handle)
@@ -114,7 +114,7 @@ sequenceDiagram
     PCB-->>AppB: transceiver B (matchable per JSEP §5.10)
 
     AppB->>SB: CreateSframeEncrypterOrError(options)
-    SB->>TB: TryEnableSframe() via observer
+    SB->>TB: TryToEnableSframe() via observer
     Note over TB: SFrame marked as enabled
     TB-->>SB: RTCError::OK()
     SB-->>AppB: RTCErrorOr<SframeEncrypterInterface> (key handle)
@@ -165,7 +165,7 @@ sequenceDiagram
     PCA-->>AppA: transceiver A
 
     AppA->>SA: CreateSframeEncrypterOrError(options)
-    SA->>TA: TryEnableSframe()
+    SA->>TA: TryToEnableSframe()
     Note over TA: SFrame marked as enabled
     TA-->>SA: RTCError::OK()
     SA-->>AppA: key handle
@@ -271,7 +271,7 @@ sequenceDiagram
     PCA-->>AppA: transceiver A
 
     AppA->>SA: CreateSframeEncrypterOrError(options)
-    SA->>TA: TryEnableSframe()
+    SA->>TA: TryToEnableSframe()
     Note over TA: SFrame marked as enabled
     TA-->>SA: RTCError::OK()
     SA-->>AppA: key handle
@@ -338,7 +338,7 @@ sequenceDiagram
     Note over App,T: Initial state: SFrame not enabled, media flowing
 
     App->>S: CreateSframeEncrypterOrError(options)
-    S->>T: TryEnableSframe()
+    S->>T: TryToEnableSframe()
     Note over T: SFrame marked as enabled
     T-->>S: RTCError::OK()
     S-->>App: RTCErrorOr<SframeEncrypterInterface>
@@ -380,7 +380,7 @@ sequenceDiagram
     Note over App,T: Later, application tries to enable SFrame...
 
     App->>S: CreateSframeEncrypterOrError(options)
-    S->>T: TryEnableSframe()
+    S->>T: TryToEnableSframe()
     T-->>S: ❌ INVALID_MODIFICATION
     S-->>App: RTCError(INVALID_MODIFICATION)
     Note over App: "Cannot enable SFrame after<br/>negotiation completed without it"


### PR DESCRIPTION
# SFrame Encrypter/Decrypter Public API

## Summary

Adds public API surface for SFrame (Secure Frame) encryption and decryption to the WebRTC PeerConnection layer. This introduces new header-only interfaces under `api/sframe/`, factory methods on `RtpSenderInterface` and `RtpReceiverInterface`, and stub implementations in the `pc/` layer ready for future wiring.

**Bug:** [bugs.webrtc.org/479862368](https://bugs.webrtc.org/479862368)